### PR TITLE
Fixed most hairlines for iPhone6 plus and other retina devices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 build
 custom
 npm-debug.log
+.idea

--- a/src/less/content-block.less
+++ b/src/less/content-block.less
@@ -31,10 +31,13 @@
     border-bottom: 1px solid @contentBlockBorderColor;
     border-top: 1px solid @contentBlockBorderColor;
     color: #000;
-    html.retina.ios-gt-7 & {
-        border-top-width: 0.5px;
-        border-bottom-width: 0.5px;
-    }
+}
+html.retina.ios-gt-7 .content-block-inner {
+    position: relative;
+    border-top-width: 0;
+    border-bottom-width: 0;
+    .hairline-top();
+    .hairline-bottom();
 }
 .content-block.inset {
     margin-left: 15px;

--- a/src/less/lists.less
+++ b/src/less/lists.less
@@ -395,6 +395,7 @@
 html.retina.ios-gt-7 {
     .list-block {
         ul {
+            position: relative;
             border-top-width: 0;
             border-bottom-width: 0;
             .hairline-top();
@@ -402,16 +403,19 @@ html.retina.ios-gt-7 {
         }
         li:not(:last-child) {
             .item-inner{
+                position: relative;
                 border-bottom-width: 0;
                 .hairline-bottom();
             }
         }
     }
     .item-divider {
+        position: relative;
         border-top-width: 0;
         .hairline-top();
     }
     .item-link.list-button {
+        position: relative;
         border-bottom-width: 0;
         .hairline-bottom();
     }

--- a/src/less/lists.less
+++ b/src/less/lists.less
@@ -395,25 +395,101 @@
 html.retina.ios-gt-7 {
     .list-block {
         ul {
-            border-top-width: 0;
-            border-bottom-width: 0;
-        }
-        li:not(:last-child) {
-            .item-inner{
-                position: relative;
-                border-bottom-width: 0;
-                .hairline-bottom();
+            ul {
+                border-top: none;
+                border-bottom: none;
+                .hairline-clear-top();
+                .hairline-clear-bottom();
             }
         }
     }
-    .item-divider {
-        position: relative;
-        border-top-width: 0;
-        .hairline-top();
+    :not(.popover-inner) {
+        > .list-block.inset {
+            ul {
+                border-top-width: 0;
+                border-bottom-width: 0;
+                ul {
+                    border-top: none;
+                    border-bottom: none;
+                    .hairline-clear-top();
+                    .hairline-clear-bottom();
+                }
+            }
+            li:not(:last-child) {
+                .item-inner {
+                    position: relative;
+                    border-bottom-width: 0;
+                    .hairline-bottom();
+                }
+                .item-divider {
+                    position: relative;
+                    border-top-width: 0;
+                    .hairline-top();
+                }
+                .item-link.list-button {
+                    position: relative;
+                    border-bottom-width: 0;
+                    .hairline-bottom();
+                }
+            }
+        }
+        > .list-block:not(.inset) {
+            ul {
+                position: relative;
+                border-top-width: 0;
+                border-bottom-width: 0;
+                .hairline-top();
+                .hairline-bottom();
+                ul {
+                    border-top: none;
+                    border-bottom: none;
+                    .hairline-clear-top();
+                    .hairline-clear-bottom();
+                }
+            }
+            li:not(:last-child) {
+                .item-inner {
+                    position: relative;
+                    border-bottom-width: 0;
+                    .hairline-bottom();
+                }
+                .item-divider {
+                    position: relative;
+                    border-top-width: 0;
+                    .hairline-top();
+                }
+                .item-link.list-button {
+                    position: relative;
+                    border-bottom-width: 0;
+                    .hairline-bottom();
+                }
+            }
+        }
     }
-    .item-link.list-button {
-        position: relative;
-        border-bottom-width: 0;
-        .hairline-bottom();
+    .popover-inner {
+        .list-block {
+            ul {
+                border-top-width: 0;
+                border-bottom-width: 0;
+            }
+            li:not(:last-child) {
+                .item-inner{
+                    position: relative;
+                    border-bottom-width: 0;
+                    .hairline-bottom();
+                }
+                .item-divider:not(:first-child) {
+                    position: relative;
+                    border-top-width: 0;
+                    border-bottom-width: 0;
+                    .hairline-bottom();
+                }
+                .item-link.list-button {
+                    position: relative;
+                    border-bottom-width: 0;
+                    .hairline-bottom();
+                }
+            }
+        }
     }
 }

--- a/src/less/lists.less
+++ b/src/less/lists.less
@@ -395,11 +395,8 @@
 html.retina.ios-gt-7 {
     .list-block {
         ul {
-            position: relative;
             border-top-width: 0;
             border-bottom-width: 0;
-            .hairline-top();
-            .hairline-bottom();
         }
         li:not(:last-child) {
             .item-inner{

--- a/src/less/lists.less
+++ b/src/less/lists.less
@@ -395,20 +395,24 @@
 html.retina.ios-gt-7 {
     .list-block {
         ul {
-            border-top-width: 0.5px;
-            border-bottom-width: 0.5px;
+            border-top-width: 0;
+            border-bottom-width: 0;
+            .hairline-top();
+            .hairline-bottom();
         }
         li:not(:last-child) {
             .item-inner{
-                border-bottom-width: 0.5px;
+                border-bottom-width: 0;
+                .hairline-bottom();
             }
         }
     }
     .item-divider {
-        border-top-width: 0.5px;
-        margin-top: -0.5px;
+        border-top-width: 0;
+        .hairline-top();
     }
     .item-link.list-button {
-        border-bottom-width: 0.5px;   
+        border-bottom-width: 0;
+        .hairline-bottom();
     }
 }

--- a/src/less/mixins.less
+++ b/src/less/mixins.less
@@ -170,3 +170,29 @@
         height: 0;
     }
 }
+.hairline-clear-top() {
+    &:before {
+        position: absolute;
+        top: 0;
+        left: 0;
+        border-top: 0 none;
+        transform: scaleY(1);
+        -webkit-transform: scaleY(1);
+        content: "";
+        width: 100%;
+        height: 0;
+    }
+}
+.hairline-clear-bottom() {
+    &:after {
+        position: absolute;
+        bottom: 0;
+        left: 0;
+        border-bottom: 0 none;
+        transform: scaleY(1);
+        -webkit-transform: scaleY(1);
+        content: "";
+        width: 100%;
+        height: 0;
+    }
+}

--- a/src/less/mixins.less
+++ b/src/less/mixins.less
@@ -142,3 +142,29 @@
         clear: both;
     }
 }
+.hairline-top() {
+    &:before {
+        position: absolute;
+        top: 0;
+        left: 0;
+        border-top: 1px solid #c8c7cc;
+        transform: scaleY(0.5);
+        -webkit-transform: scaleY(0.5);
+        content: "";
+        width: 100%;
+        height: 0;
+    }
+}
+.hairline-bottom() {
+    &:after {
+        position: absolute;
+        bottom: 0;
+        left: 0;
+        border-bottom: 1px solid #c8c7cc;
+        transform: scaleY(0.5);
+        -webkit-transform: scaleY(0.5);
+        content: "";
+        width: 100%;
+        height: 0;
+    }
+}

--- a/src/less/mixins.less
+++ b/src/less/mixins.less
@@ -1,3 +1,5 @@
+@contentHairlineBorderColor: #c8c7cc;
+
 .transition(@d) {
     -webkit-transition-duration: @d;
     transition-duration: @d;
@@ -147,7 +149,7 @@
         position: absolute;
         top: 0;
         left: 0;
-        border-top: 1px solid #c8c7cc;
+        border-top: 1px solid @contentHairlineBorderColor;
         transform: scaleY(0.5);
         -webkit-transform: scaleY(0.5);
         content: "";
@@ -160,7 +162,7 @@
         position: absolute;
         bottom: 0;
         left: 0;
-        border-bottom: 1px solid #c8c7cc;
+        border-bottom: 1px solid @contentHairlineBorderColor;
         transform: scaleY(0.5);
         -webkit-transform: scaleY(0.5);
         content: "";

--- a/src/less/modals.less
+++ b/src/less/modals.less
@@ -466,18 +466,23 @@ html.with-statusbar-overlay {
 }
 html.retina.ios-gt-7 {
     .modal-inner {
-        border-bottom-width: 0.5px;
+        border-bottom-width: 0;
+        .hairline-bottom();
     }
     .modal-button {
+        // todo: figure out how to do right
         border-right-width: 0.5px;   
     }
     .actions-modal-button, .actions-modal-label {
-        border-bottom-width: 0.5px;   
+        border-bottom-width: 0;
+        .hairline-bottom();
     }
     .actions-popover-label {
-        border-bottom-width: 0.5px;
+        border-bottom-width: 0;
+        .hairline-bottom();
     }
     input.modal-text-input {
+        // todo: figure out how to do all
         border-width: 0.5px;
     }
 

--- a/src/less/modals.less
+++ b/src/less/modals.less
@@ -466,6 +466,7 @@ html.with-statusbar-overlay {
 }
 html.retina.ios-gt-7 {
     .modal-inner {
+        position: relative;
         border-bottom-width: 0;
         .hairline-bottom();
     }
@@ -474,10 +475,12 @@ html.retina.ios-gt-7 {
         border-right-width: 0.5px;   
     }
     .actions-modal-button, .actions-modal-label {
+        position: relative;
         border-bottom-width: 0;
         .hairline-bottom();
     }
     .actions-popover-label {
+        position: relative;
         border-bottom-width: 0;
         .hairline-bottom();
     }

--- a/src/less/modals.less
+++ b/src/less/modals.less
@@ -474,7 +474,7 @@ html.retina.ios-gt-7 {
         // todo: figure out how to do right
         border-right-width: 0.5px;   
     }
-    .actions-modal-button, .actions-modal-label {
+    .actions-modal-button:not(:last-child), .actions-modal-label {
         position: relative;
         border-bottom-width: 0;
         .hairline-bottom();

--- a/src/less/searchbar.less
+++ b/src/less/searchbar.less
@@ -12,7 +12,8 @@
     .flexbox();
     .align-items(center);
     html.retina.ios-gt-7 & {
-        border-bottom-width: 0.5px;
+        border-bottom-width: 0;
+        .hairline-bottom();
     }
     .searchbar-input {
         width: 100%;

--- a/src/less/searchbar.less
+++ b/src/less/searchbar.less
@@ -12,6 +12,7 @@
     .flexbox();
     .align-items(center);
     html.retina.ios-gt-7 & {
+        position: relative;
         border-bottom-width: 0;
         .hairline-bottom();
     }

--- a/src/less/toolbars.less
+++ b/src/less/toolbars.less
@@ -65,7 +65,8 @@
     background: @navbarBg;
     border-bottom: 1px solid @navbarBorderColor;
     html.retina.ios-gt-7 & {
-        border-bottom-width: 0.5px;
+        border-bottom-width: 0;
+        .hairline-bottom();
     }
     .center {
         font-size: 17px;
@@ -110,7 +111,8 @@
     background: @toolbarBg;
     border-top: 1px solid @toolbarBorderColor;
     html.retina.ios-gt-7 & {
-        border-top-width: 0.5px;
+        border-top-width: 0;
+        .hairline-top();
     }
     a {
         .flex-shrink(1);

--- a/src/less/toolbars.less
+++ b/src/less/toolbars.less
@@ -65,6 +65,7 @@
     background: @navbarBg;
     border-bottom: 1px solid @navbarBorderColor;
     html.retina.ios-gt-7 & {
+        position: relative;
         border-bottom-width: 0;
         .hairline-bottom();
     }
@@ -111,6 +112,7 @@
     background: @toolbarBg;
     border-top: 1px solid @toolbarBorderColor;
     html.retina.ios-gt-7 & {
+        position: relative;
         border-top-width: 0;
         .hairline-top();
     }

--- a/src/less/toolbars.less
+++ b/src/less/toolbars.less
@@ -65,7 +65,6 @@
     background: @navbarBg;
     border-bottom: 1px solid @navbarBorderColor;
     html.retina.ios-gt-7 & {
-        position: relative;
         border-bottom-width: 0;
         .hairline-bottom();
     }
@@ -112,7 +111,6 @@
     background: @toolbarBg;
     border-top: 1px solid @toolbarBorderColor;
     html.retina.ios-gt-7 & {
-        position: relative;
         border-top-width: 0;
         .hairline-top();
     }


### PR DESCRIPTION
Before and after screenshots below.

Hairlines are more consistent throughout and also now visible in the browser (chrome when you set iPhone6 plus emulation).

TODO: Figure out how to improve hairlines for input boxes (messagebar and prompt) without impacting style or performance.


![screen shot 2014-12-14 at 11 14 16 am](https://cloud.githubusercontent.com/assets/5016637/5428017/8ad7b1d2-8382-11e4-891b-4de2d132bc5b.png)
![screen shot 2014-12-14 at 11 15 12 am](https://cloud.githubusercontent.com/assets/5016637/5428016/8ad73572-8382-11e4-9a45-be78d4bfdc13.png)

 

![ios simulator screen shot dec 14 2014 11 09 35 am](https://cloud.githubusercontent.com/assets/5016637/5427967/128566f2-8382-11e4-9aa3-060c9b378d73.png)
![ios simulator screen shot dec 14 2014 11 04 02 am](https://cloud.githubusercontent.com/assets/5016637/5427968/128a185a-8382-11e4-98d4-6341d3dacba4.png)
![ios simulator screen shot dec 14 2014 11 09 45 am](https://cloud.githubusercontent.com/assets/5016637/5427969/128d7284-8382-11e4-8af5-8f6f3940dbd9.png)
![ios simulator screen shot dec 14 2014 11 05 03 am](https://cloud.githubusercontent.com/assets/5016637/5427970/12918126-8382-11e4-9ad2-b20d98357e56.png)