### PR TITLE
Prevent scrolling through overlays

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 build
 custom
 npm-debug.log
+.idea

--- a/src/js/panels.js
+++ b/src/js/panels.js
@@ -150,6 +150,11 @@ app.initSwipePanels = function () {
                 return;
             }
         }
+        // prevents scrolling of panel overlay
+        function touchPanel() {
+            panelOverlay.click();
+            panelOverlay.off('touchstart', touchPanel);
+        }
 
         if (app.params.swipePanelNoFollow) {
             var timeDiff = (new Date()).getTime() - touchStartTime;
@@ -173,6 +178,7 @@ app.initSwipePanels = function () {
             if (!opened) {
                 panel.show();
                 panelOverlay.show();
+                panelOverlay.on('touchstart', touchPanel);
             }
             panelWidth = panel[0].offsetWidth;
             panel.transition(0);
@@ -180,7 +186,6 @@ app.initSwipePanels = function () {
                 if (app.sizeNavbars) app.sizeNavbars(panel.find('.' + app.params.viewClass)[0]);
             }
         }
-
         isMoved = true;
 
         e.preventDefault();

--- a/src/js/searchbar.js
+++ b/src/js/searchbar.js
@@ -108,7 +108,7 @@ app.initSearchbar = function (pageContainer) {
         var method = destroy ? 'off' : 'on';
         searchbar[method]('submit', preventSubmit);
         cancel[method]('click', disableSearchbar);
-        searchbarOverlay[method]('click', disableSearchbar);
+        searchbarOverlay[method]('click touchstart', disableSearchbar);
         input[method]('focus', enableSearchbar);
         input[method]('change keydown keypress keyup', searchValue);
         clear[method]('click', clearSearchbar);


### PR DESCRIPTION
make the touch move event function like a click event to prevent
scrolling through the overlay