### PR TITLE
Added external click for cordova

### DIFF
--- a/src/js/clicks.js
+++ b/src/js/clicks.js
@@ -16,13 +16,13 @@ app.initClickEvents = function () {
         }
         // Check if link is external 
         if (isLink) {
-            if (clicked.is(app.params.externalLinks) && clicked.attr('target') && clicked.attr('target') === '_system') {
-                window.open(url, '_system');
-                e.preventDefault();
-                return;
-            } else if (clicked.is(app.params.externalLinks)) {
-                return;
+          if (clicked.is(app.params.extenalLinks) {
+            if(clicked.attr('target') === '_system') {
+              e.preventDefault();
+              window.open(url, '_system');
             }
+            return;
+          }
         }
 
         // Smart Select

--- a/src/js/clicks.js
+++ b/src/js/clicks.js
@@ -16,7 +16,7 @@ app.initClickEvents = function () {
         }
         // Check if link is external 
         if (isLink) {
-          if (clicked.is(app.params.extenalLinks) {
+          if (clicked.is(app.params.extenalLinks)) {
             if(clicked.attr('target') === '_system') {
               e.preventDefault();
               window.open(url, '_system');

--- a/src/js/clicks.js
+++ b/src/js/clicks.js
@@ -16,7 +16,13 @@ app.initClickEvents = function () {
         }
         // Check if link is external 
         if (isLink) {
-            if (clicked.is(app.params.externalLinks)) return;
+            if (clicked.is(app.params.externalLinks) && clicked.attr('target') && clicked.attr('target') === '_system') {
+                window.open(url, '_system');
+                e.preventDefault();
+                return;
+            } else if (clicked.is(app.params.externalLinks)) {
+                return;
+            }
         }
 
         // Smart Select


### PR DESCRIPTION
I tried many ways to not include this in the library, but it must be.

The _system target is original enough and should only ever be used for cordova apps.