### PR TITLE
use new class smart-select-value to set selected option in Smart Select

### DIFF
--- a/src/js/smart-select.js
+++ b/src/js/smart-select.js
@@ -27,7 +27,14 @@ app.initSmartSelects = function (pageContainer) {
             smartSelect.find('.item-inner').append('<div class="item-after">' + valueText.join(', ') + '</div>');
         }
         else {
-            itemAfter.text(valueText);
+            var selectedText = itemAfter.text();
+            if (itemAfter.hasClass('smart-select-value')) {
+                for (i = 0; i < select.length; i++) {
+                    select[i].selected = select[i].textContent.trim() === selectedText.trim();
+                }
+            } else {
+                itemAfter.text(valueText);
+            }
         }
         
     });


### PR DESCRIPTION
Smart Select automatically sets div.item-after to be the selected option. But there is another use case missing that is to set selected option based on a value. This change is to implement the missing use case. 

Adding a value to div.item-after and also add a new class smart-select-value to it will set the select option which matches the value to be selected.