### PR TITLE
increase the pull distance that triggers pull to refresh

### DIFF
--- a/src/js/pull-to-refresh.js
+++ b/src/js/pull-to-refresh.js
@@ -80,7 +80,7 @@ app.initPullToRefresh = function (pageContainer) {
             }
             else {
             }
-            if ((useTranslate && Math.pow(touchesDiff, 0.85) > 44) || (!useTranslate && touchesDiff >= 88)) {
+            if ((useTranslate && Math.pow(touchesDiff, 0.85) > $('body')[0].offsetHeight / 4) || (!useTranslate && touchesDiff >= 88)) {
                 refresh = true;
                 container.addClass('pull-up').removeClass('pull-down');
             }


### PR DESCRIPTION
Pull to refresh is very sensitive because it is triggered when the page is pull down for 44 pixel. This patch increase the pull distance to 1/4 of the screen.