### PR TITLE
Check if touch moved before removing active state.

### DIFF
--- a/dist/js/framework7.js
+++ b/dist/js/framework7.js
@@ -5922,12 +5922,11 @@
                     trackClick = false;
                     targetElement = null;
                     isMoved = true;
-                }
-                    
-                if (app.params.activeState) {
-                    clearTimeout(activeTimeout);
-                    removeActive();
-                }
+					if (app.params.activeState) {
+						clearTimeout(activeTimeout);
+						removeActive();
+					}
+                }                    
             }
             function handleTouchEnd(e) {
                 clearTimeout(activeTimeout);

--- a/dist/js/framework7.js
+++ b/dist/js/framework7.js
@@ -5923,7 +5923,7 @@
                     targetElement = null;
                     isMoved = true;
                 }
-
+                    
                 if (app.params.activeState) {
                     clearTimeout(activeTimeout);
                     removeActive();

--- a/dist/js/framework7.js
+++ b/dist/js/framework7.js
@@ -5924,11 +5924,10 @@
                     isMoved = true;
                 }
 
-				if (app.params.activeState) {
-					clearTimeout(activeTimeout);
-					removeActive();
-				}
-
+                if (app.params.activeState) {
+                    clearTimeout(activeTimeout);
+                    removeActive();
+                }
             }
             function handleTouchEnd(e) {
                 clearTimeout(activeTimeout);

--- a/dist/js/framework7.js
+++ b/dist/js/framework7.js
@@ -5907,7 +5907,7 @@
             function handleTouchMove(e) {
                 if (!trackClick) return;
                 var _isMoved = false;
-                var distance = app.params.fastClicksDistanceThreshold * app.device.pixelRatio;
+                var distance = app.params.fastClicksDistanceThreshold;
                 if (distance) {
                     var pageX = e.targetTouches[0].pageX;
                     var pageY = e.targetTouches[0].pageY;
@@ -5922,11 +5922,13 @@
                     trackClick = false;
                     targetElement = null;
                     isMoved = true;
-					if (app.params.activeState) {
-						clearTimeout(activeTimeout);
-						removeActive();
-					}
-                }                    
+                }
+
+				if (app.params.activeState) {
+					clearTimeout(activeTimeout);
+					removeActive();
+				}
+
             }
             function handleTouchEnd(e) {
                 clearTimeout(activeTimeout);

--- a/dist/js/framework7.js
+++ b/dist/js/framework7.js
@@ -5907,7 +5907,7 @@
             function handleTouchMove(e) {
                 if (!trackClick) return;
                 var _isMoved = false;
-                var distance = app.params.fastClicksDistanceThreshold;
+                var distance = app.params.fastClicksDistanceThreshold * app.device.pixelRatio;
                 if (distance) {
                     var pageX = e.targetTouches[0].pageX;
                     var pageY = e.targetTouches[0].pageY;

--- a/src/js/fast-clicks.js
+++ b/src/js/fast-clicks.js
@@ -179,7 +179,7 @@ app.initFastClicks = function () {
     function handleTouchMove(e) {
         if (!trackClick) return;
         var _isMoved = false;
-        var distance = app.params.fastClicksDistanceThreshold;
+        var distance = app.params.fastClicksDistanceThreshold * app.device.pixelRatio;
         if (distance) {
             var pageX = e.targetTouches[0].pageX;
             var pageY = e.targetTouches[0].pageY;

--- a/src/js/fast-clicks.js
+++ b/src/js/fast-clicks.js
@@ -179,7 +179,7 @@ app.initFastClicks = function () {
     function handleTouchMove(e) {
         if (!trackClick) return;
         var _isMoved = false;
-        var distance = app.params.fastClicksDistanceThreshold * app.device.pixelRatio;
+        var distance = app.params.fastClicksDistanceThreshold;
         if (distance) {
             var pageX = e.targetTouches[0].pageX;
             var pageY = e.targetTouches[0].pageY;
@@ -198,7 +198,7 @@ app.initFastClicks = function () {
 				clearTimeout(activeTimeout);
 				removeActive();
 			}
-        }            
+        }
     }
     function handleTouchEnd(e) {
         clearTimeout(activeTimeout);

--- a/src/js/fast-clicks.js
+++ b/src/js/fast-clicks.js
@@ -194,12 +194,11 @@ app.initFastClicks = function () {
             trackClick = false;
             targetElement = null;
             isMoved = true;
-        }
-            
-        if (app.params.activeState) {
-            clearTimeout(activeTimeout);
-            removeActive();
-        }
+			if (app.params.activeState) {
+				clearTimeout(activeTimeout);
+				removeActive();
+			}
+        }            
     }
     function handleTouchEnd(e) {
         clearTimeout(activeTimeout);


### PR DESCRIPTION
Fixes issue causing active state on elements to be prematurely removed.

See #387.