### PR TITLE
Regexp fix for the Calendar widget.

### DIFF
--- a/src/js/calendar.js
+++ b/src/js/calendar.js
@@ -109,17 +109,18 @@ var Calendar = function (params) {
         var month1 = month + 1;
         var day = date.getDate();
         var weekDay = date.getDay();
+
         return p.params.dateFormat
             .replace(/yyyy/g, year)
             .replace(/yy/g, (year + '').substring(2))
             .replace(/mm/g, month1 < 10 ? '0' + month1 : month1)
             .replace(/m/g, month1)
             .replace(/MM/g, p.params.monthNames[month])
-            .replace(/M/g, p.params.monthNamesShort[month])
+            .replace(/M\W+/g, p.params.monthNamesShort[month] + '$1')
             .replace(/dd/g, day < 10 ? '0' + day : day)
             .replace(/d/g, day)
             .replace(/DD/g, p.params.dayNames[weekDay])
-            .replace(/D/g, p.params.dayNamesShort[weekDay]);
+            .replace(/D\W+/g, p.params.dayNamesShort[weekDay] + '$1');
     }
 
 


### PR DESCRIPTION
Hi,

There is an issue in the Calendar formatter regexp. The problem is the short name of the months and days can be applied to the long name of as well, which means two different replace is applied to the same string.

My fix expects that after the short name of the day/month there must be a 'non-word' character: whitespace, punctuation, etc.

Let me know if there is a scenario where this pattern does not fit.