### PR TITLE
speedup picker on android

### DIFF
--- a/src/js/picker.js
+++ b/src/js/picker.js
@@ -193,13 +193,12 @@ var Picker = function (params) {
             if (activeIndex >= col.items.length) activeIndex = col.items.length - 1;
             var previousActiveIndex = col.activeIndex;
             col.activeIndex = activeIndex;
-            col.wrapper.find('.picker-selected, .picker-after-selected, .picker-before-selected').removeClass('picker-selected picker-after-selected picker-before-selected');
-
             col.items.transition(transition);
+            col.wrapper.find('.picker-selected').removeClass('picker-selected');
+            if (p.params.rotateEffect) {
+              col.items.transition(transition);
+            }
             var selectedItem = col.items.eq(activeIndex).addClass('picker-selected').transform('');
-            var prevItems = selectedItem.prevAll().addClass('picker-before-selected');
-            var nextItems = selectedItem.nextAll().addClass('picker-after-selected');
-                
             // Set 3D rotate effect
             if (p.params.rotateEffect) {
                 var percentage = (translate - (Math.floor((translate - maxTranslate)/itemHeight) * itemHeight + maxTranslate)) / itemHeight;


### PR DESCRIPTION
Picker is very wonderful! But it scroll very slow on android devices, even Sumsung galaxy S5.
And I found these code cause the problem in updateItems function:

              col.wrapper.find('.picker-selected, .picker-after-selected, .picker-before-selected').removeClass('picker-selected picker-after-selected picker-before-selected');

              col.items.transition(transition);
              var selectedItem = col.items.eq(activeIndex).addClass('picker-selected').transform('');
              var prevItems = selectedItem.prevAll().addClass('picker-before-selected');
              var nextItems = selectedItem.nextAll().addClass('picker-after-selected');


I removed some of unused code, and it solved the problem(only when rotateEffect is false).
