### PR TITLE
Add canceled event for swipeout elements

### DIFF
--- a/src/js/clicks.js
+++ b/src/js/clicks.js
@@ -202,11 +202,15 @@ app.initClickEvents = function () {
                 if (title) {
                     app.confirm(text, title, function () {
                         app.swipeoutDelete(clicked.parents('.swipeout'));
+                    }, function () {
+                        clicked.parents('.swipeout').trigger('canceled');
                     });
                 }
                 else {
                     app.confirm(text, function () {
                         app.swipeoutDelete(clicked.parents('.swipeout'));
+                    }, function () {
+                        clicked.parents('.swipeout').trigger('canceled');
                     });
                 }
             }


### PR DESCRIPTION
Event will be triggered after cancellation of swipeout element deletion
confirmation (confirm modal cancellation)

Usage case:

```
$$(el).on('canceled', function () {
      app.swipeoutClose($$(this));
});
```