### PR TITLE
Scan Dates Range, array accept mixed types (single date + date range)

### DIFF
--- a/src/js/calendar.js
+++ b/src/js/calendar.js
@@ -350,9 +350,7 @@ var Calendar = function (params) {
         if (!range) return false;
         if ($.isArray(range)) {
             for (i = 0; i < range.length; i ++) {
-                if (dayDate === new Date(range[i]).getTime()) {
-                    match = true;
-                } else if (range[i].from || range[i].to) {
+                if (range[i].from || range[i].to) {
                     if (range[i].from && range[i].to) {
                         if ((dayDate <= new Date(range[i].to).getTime()) && (dayDate >= new Date(range[i].from).getTime())) {
                             match = true;   
@@ -368,7 +366,9 @@ var Calendar = function (params) {
                             match = true;   
                         }
                     }
-                }
+                } else if (dayDate === new Date(range[i]).getTime()) {
+                    match = true;
+                } 
             }
         }
         else if (range.from || range.to) {

--- a/src/js/calendar.js
+++ b/src/js/calendar.js
@@ -352,6 +352,22 @@ var Calendar = function (params) {
             for (i = 0; i < range.length; i ++) {
                 if (dayDate === new Date(range[i]).getTime()) {
                     match = true;
+                } else if (range[i].from || range[i].to) {
+                    if (range[i].from && range[i].to) {
+                        if ((dayDate <= new Date(range[i].to).getTime()) && (dayDate >= new Date(range[i].from).getTime())) {
+                            match = true;   
+                        }
+                    }
+                    else if (range[i].from) {
+                        if (dayDate >= new Date(range[i].from).getTime()) {
+                            match = true;   
+                        }
+                    }
+                    else if (range[i].to) {
+                        if (dayDate <= new Date(range[i].to).getTime()) {
+                            match = true;   
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
update for **dateInRange** function that scan date ranges for events, disabled dates etc.. in calendar. now can include date ranges in array to match multiple ranges.
example: 
```javascript
var calendarMultiple = myApp.calendar({
    input: '#calendar',
    events: [
        new Date(2015, 9, 1),
        new Date(2015, 9, 5),
        {
            from: new Date(2015, 9, 10),
            to: new Date(2015, 9, 15)
        },
        {
            from: new Date(2015, 9, 20),
            to: new Date(2015, 9, 31)
        }
    ],
    disabled: [
        new Date(2015, 9, 3),
        new Date(2015, 9, 7),
        {
            from: new Date(2015, 9, 16),
            to: new Date(2015, 9, 19)
        },
        {
            from: new Date(2015, 9, 28),
            to: new Date(2015, 9, 31)
        }
    ],
});
```
will result in
![calendarex](https://cloud.githubusercontent.com/assets/11189145/10448513/ef76b140-7195-11e5-858f-cfe12679aead.PNG)

I know one could have used a custom function to achieve such result, but this is much more convenient and easy to use and read.