### PR TITLE
.item-inner overflow control

### DIFF
--- a/src/less/material/lists.less
+++ b/src/less/material/lists.less
@@ -83,6 +83,8 @@
         position: relative;
         .hairline(bottom, @listBlockBorderColor);
         width: 100%;
+        overflow: hidden;
+        text-overflow: ellipsis;
         padding-top: 8px;
         padding-bottom: 8px;
         min-height: 48px;

--- a/src/less/material/lists.less
+++ b/src/less/material/lists.less
@@ -84,7 +84,6 @@
         .hairline(bottom, @listBlockBorderColor);
         width: 100%;
         overflow: hidden;
-        text-overflow: ellipsis;
         padding-top: 8px;
         padding-bottom: 8px;
         min-height: 48px;


### PR DESCRIPTION
Fixes #661, preventing horizontal scrolling caused by form labels.
![20151014-173118_capture](https://cloud.githubusercontent.com/assets/2397125/10489220/5e8abe44-729c-11e5-93f3-374b2f37d043.gif)
