### PR TITLE
Add support for DOM content in router.preprocess

### DIFF
--- a/src/js/router.js
+++ b/src/js/router.js
@@ -262,7 +262,7 @@ app.router._load = function (view, options) {
 
     // Parse DOM
     if (!pageName) {
-        if (url || (typeof content === 'string')) {
+        if ((typeof content === 'string') || (url && (typeof content === 'string'))) {
             app.router.temporaryDom.innerHTML = t7_rendered.content;
         } else {
             if ('length' in content && content.length > 1) {
@@ -716,7 +716,7 @@ app.router._back = function (view, options) {
     function parseNewPage() {
         app.router.temporaryDom.innerHTML = '';
         // Parse DOM
-        if (url || (typeof content === 'string')) {
+        if ((typeof content === 'string') || (url && (typeof content === 'string'))) {
             app.router.temporaryDom.innerHTML = t7_rendered.content;
         } else {
             if ('length' in content && content.length > 1) {


### PR DESCRIPTION
I wish to use Angular + Framework7 together. For that i should compile pages content with angular.$compile. I use router.preprocess to achive this. But $compile returns DOM element with angular scope, so i can't return HTML text from preprocess function. In this PR router is modifed with additional check. If content is not string then router appends content and don't use innerHTML field.

Example of my preprocess function:
```coffeescript
    @framework7 = new Framework7
      swipePanel: 'left'
      preprocess: (content, url, next) =>
        compiled = @compile content
        compiledContent = compiled @scope
        compiledContent
```