### PR TITLE
Fix dom7 parent

### DIFF
--- a/src/js/dom7-methods.js
+++ b/src/js/dom7-methods.js
@@ -649,11 +649,13 @@ Dom7.prototype = {
     parent: function (selector) {
         var parents = [];
         for (var i = 0; i < this.length; i++) {
-            if (selector) {
-                if ($(this[i].parentNode).is(selector)) parents.push(this[i].parentNode);
-            }
-            else {
-                parents.push(this[i].parentNode);
+            if (this[i].parentNode !== null) {
+                if (selector) {
+                    if ($(this[i].parentNode).is(selector)) parents.push(this[i].parentNode);
+                }
+                else {
+                   parents.push(this[i].parentNode);
+                }
             }
         }
         return $($.unique(parents));


### PR DESCRIPTION
If the case of `this[0].parentNode => null`, to become `parents => [null]`.
This Error has occurred when using an Dynamic Pages.

From

```
// Accordion
if (clicked.hasClass('accordion-item-toggle') || (clicked.hasClass('item-link') && clicked.parent().hasClass('accordion-item'))) {
```
