### PR TITLE
Fix condition for bars reappearance

### DIFF
--- a/src/js/scroll-toolbars.js
+++ b/src/js/scroll-toolbars.js
@@ -40,13 +40,15 @@ app.initScrollToolbars = function (pageContainer) {
         currentScroll = scrollContent[0].scrollTop;
         scrollHeight = scrollContent[0].scrollHeight;
         offsetHeight = scrollContent[0].offsetHeight;
-        reachEnd = app.params.showBarsOnPageScrollEnd && (currentScroll + offsetHeight >= scrollHeight - bottomBarHeight);
+        reachEnd =  (currentScroll + offsetHeight >= scrollHeight - bottomBarHeight);
         navbarHidden = navbar.hasClass('navbar-hidden');
         toolbarHidden = toolbar.hasClass('toolbar-hidden');
         tabbarHidden = tabbar && tabbar.hasClass('toolbar-hidden');
 
         if (reachEnd) {
-            action = 'show';
+            if (app.params.showBarsOnPageScrollEnd) {
+                action = 'show';
+            }
         }
         else if (previousScroll > currentScroll) {
             if (app.params.showBarsOnPageScrollTop || currentScroll <= 44) {


### PR DESCRIPTION
This fix prevents bars to be reappeared even if showBarsOnPageScrollEnd is false when the screen scrolls to end and bounces.