### PR TITLE
add onlyImage field to messages properties

### DIFF
--- a/src/js/messages.js
+++ b/src/js/messages.js
@@ -102,6 +102,7 @@ var Messages = function (container, params) {
             props.type = props.type || 'sent';
             if (!props.text) continue;
             props.hasImage = props.text.indexOf('<img') >= 0;
+            props.onlyImage = props.text.indexOf('<img') == 0;
             if (animate) props.position = method === 'append' ? 'bottom' : 'top';
 
             newMessagesHTML += m.template(props);

--- a/src/js/messages.js
+++ b/src/js/messages.js
@@ -9,7 +9,7 @@ var Messages = function (container, params) {
             '{{#if day}}' +
             '<div class="messages-date">{{day}} {{#if time}}, <span>{{time}}</span>{{/if}}</div>' +
             '{{/if}}' +
-            '<div class="message message-{{type}} {{#if hasImage}}message-pic{{/if}} {{#if avatar}}message-with-avatar{{/if}} {{#if position}}message-appear-from-{{position}}{{/if}}">' +
+            '<div class="message message-{{type}} {{#if onlyImage}}message-pic{{/if}} {{#if avatar}}message-with-avatar{{/if}} {{#if position}}message-appear-from-{{position}}{{/if}}">' +
                 '{{#if name}}<div class="message-name">{{name}}</div>{{/if}}' +
                 '<div class="message-text">{{text}}{{#if date}}<div class="message-date">{{date}}</div>{{/if}}</div>' +
                 '{{#if avatar}}<div class="message-avatar" style="background-image:url({{avatar}})"></div>{{/if}}' +


### PR DESCRIPTION
I came across this problem when adding emojis to a message field - emojione converts into images, which are embedded in the message text.  However, the css for message-pic doesn't play well with text, which makes sense.  I thought it appropriate to add in another field to determine not only if there is an image anywhere in the text, but if it is the beginning (and assumed to be the only significant text, so we can apply message-pic).  For me, I disable autoLayout and use onlyImage to add message-pic class to the messages display like this, and it works well.
