### PR TITLE
fixes for nested views: issue #1082 and issue on virtual-list.js

### DIFF
--- a/src/js/router.js
+++ b/src/js/router.js
@@ -300,7 +300,7 @@ app.router._load = function (view, options) {
         oldPage = pagesInView.eq(pagesInView.length - 1);
     }
     else {
-        if (pagesInView.length > 1) {
+        if (!view.params.domCache && pagesInView.length > 1) {
             for (i = 0; i < pagesInView.length - 2; i++) {
                 if (!view.params.domCache) {
                     app.pageRemoveCallback(view, pagesInView[i], 'left');

--- a/src/js/virtual-list.js
+++ b/src/js/virtual-list.js
@@ -258,8 +258,12 @@ var VirtualList = function (listBlock, params) {
     };
     // Handle resize event
     vl.handleResize = function (e) {
-        vl.setListSize();
-        vl.render(true);
+        if ((function (elem) {
+                return !!( elem.offsetWidth || elem.offsetHeight || elem.getClientRects().length );
+            })(vl.listBlock[0])) {
+            vl.setListSize();
+            vl.render(true);
+        }
     };
 
     vl.attachEvents = function (detach) {


### PR DESCRIPTION
- Now it checks if the vl.listBlock element is visible before it does the resizing- and rendering-call. Like this, the virtual list won't be overwritten with wrong content when it's not visible. This happens when you have a routing with more than 1 level because just the current back-page keeps visible.
- Also fixed the following issue: https://github.com/nolimits4web/Framework7/issues/1082
