### PR TITLE
Catch formFromJson event to resize textareas on load

### DIFF
--- a/src/js/forms-textarea.js
+++ b/src/js/forms-textarea.js
@@ -49,6 +49,10 @@ app.initPageResizableTextarea = function (pageContainer) {
     pageContainer = $(pageContainer);
     var textareas = pageContainer.find('textarea.resizable');
     textareas.each(function () {
-        app.resizableTextarea(this);
+        var textarea = this;
+        app.resizableTextarea(textarea);
+        pageContainer.on('formFromJSON', function() {
+            app.resizeTextarea(textarea);
+        })
     });
 };


### PR DESCRIPTION
Added `.on('formFromJSON')` listener to automatically resize `resizeable` textareas on load.
