### PR TITLE
Add fastClicksExclude param to exclude nodes as fastclick targets

### DIFF
--- a/src/js/dom7-ajax.js
+++ b/src/js/dom7-ajax.js
@@ -192,7 +192,7 @@ $.ajax = function (options) {
         options.crossDomain = /^([\w-]+:)?\/\/([^\/]+)/.test(options.url) && RegExp.$2 !== window.location.host;
     }
 
-    if (!options.crossDomain) {
+    if (options.crossDomain) {
         xhr.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
     }
 

--- a/src/js/f7-intro.js
+++ b/src/js/f7-intro.js
@@ -31,6 +31,7 @@ window.Framework7 = function (params) {
         fastClicks: true,
         fastClicksDistanceThreshold: 10,
         fastClicksDelayBetweenClicks: 50,
+        fastClicksExclude: '', // CSS selector
         // Tap Hold
         tapHold: false,
         tapHoldDelay: 750,

--- a/src/js/fast-clicks.js
+++ b/src/js/fast-clicks.js
@@ -76,6 +76,7 @@ app.initFastClicks = function () {
         var $el = $(el);
         if (el.nodeName.toLowerCase() === 'input' && el.type === 'file') return false;
         if ($el.hasClass('no-fastclick') || $el.parents('.no-fastclick').length > 0) return false;
+        if (app.params.fastClicksExclude && $el.is(app.params.fastClicksExclude)) return false;
         return true;
     }
     function targetNeedsFocus(el) {


### PR DESCRIPTION
Fastclick implementation causes the Google's Places API `place_changed` event to not fire when clicking on an auto-completed place.  To overcome this, and still use fastclicks in your app, users needed to [listen for the 'DOMNodeInserted' event](http://stackoverflow.com/questions/9972080/cant-tap-on-item-in-google-autocomplete-list-on-mobile#34628921) and add `.no-fastclick` classes to all child nodes of `.pac-container` which causes performance issues.

This PR implements a CSS Selector param instead to exclude nodes from being a fastclick target and so the items returned by the Places API can be excluded like the example below.

```
var myApp = new Framework7({
    fastClicksExclude: '.pac-item, .pac-item span', // CSS Selector
    // ... other parameters
});
```

Stackoverflow:
http://stackoverflow.com/questions/9972080/cant-tap-on-item-in-google-autocomplete-list-on-mobile#34628921
http://stackoverflow.com/questions/17160220/google-places-autocomplete-with-jquery-mobile-not-working-on-mobile-touch-device/17176350#20056569

Bugs:
https://github.com/nolimits4web/Framework7/issues/888
https://github.com/nolimits4web/Framework7/issues/95