### PR TITLE
Fixed incorrect vrirtual list height

### DIFF
--- a/src/js/virtual-list.js
+++ b/src/js/virtual-list.js
@@ -104,7 +104,7 @@ var VirtualList = function (listBlock, params) {
             }
         }
         else {
-            listHeight = items.length * vl.params.height / vl.params.cols;
+            listHeight = Math.ceil(items.length /  vl.params.cols) * vl.params.height;
             rowsPerScreen = Math.ceil(pageHeight / vl.params.height);
             rowsBefore = vl.params.rowsBefore || rowsPerScreen * 2;
             rowsAfter = vl.params.rowsAfter || rowsPerScreen;


### PR DESCRIPTION
This is a small bugfix, sorry I did not open an issue first but the solution seemed trivial and only seems to be an oversight.

When using multiple columns virtual list does not properly change it's height. This change fixes it to always round up to the current column height and prevent weird layouts when a row is not entirely filled with columns.