### PR TITLE
Fix invalid view history with an empty pushStateSeparator

### DIFF
--- a/src/js/views.js
+++ b/src/js/views.js
@@ -99,7 +99,7 @@ var View = function (selector, params) {
             viewURL = pushStateRoot;
         }
         else {
-            if (viewURL.indexOf(pushStateSeparator) >= 0 && viewURL.indexOf(pushStateSeparator + '#') < 0) viewURL = viewURL.split(pushStateSeparator)[0];
+            if (pushStateSeparator && viewURL.indexOf(pushStateSeparator) >= 0 && viewURL.indexOf(pushStateSeparator + '#') < 0) viewURL = viewURL.split(pushStateSeparator)[0];
         }
 
     }


### PR DESCRIPTION
When `pushStateSeparator == ''`, the view history has a invalid entry `'h'` and causes a XHR error.

Fixes #1004.
