### PR TITLE
Fix for id #1056 (Wrong "style: left" on subnavbar in case of navbar with no right + subnavbar with left and right)

### DIFF
--- a/src/js/navbars.js
+++ b/src/js/navbars.js
@@ -97,7 +97,7 @@ app.initNavbarWithCallback = function (navbarContainer) {
 // Size Navbars
 app.sizeNavbars = function (viewContainer) {
     if (app.params.material) return;
-    var navbarInner = viewContainer ? $(viewContainer).find('.navbar .navbar-inner:not(.cached)') : $('.navbar .navbar-inner:not(.cached)');
+    var navbarInner = viewContainer ? $(viewContainer).find('.navbar .navbar-inner:not(.cached), .navbar .subnavbar:not(.cached)') : $('.navbar .navbar-inner:not(.cached), .navbar .subnavbar:not(.cached)');
     navbarInner.each(function () {
         var n = $(this);
         if (n.hasClass('cached')) return;
@@ -187,7 +187,7 @@ app.sizeNavbars = function (viewContainer) {
         var centerLeft = diff;
         if (app.rtl && noLeft && noRight && center.length > 0) centerLeft = -centerLeft;
         center.css({left: centerLeft + 'px'});
-        
+
     });
 };
 

--- a/src/js/navbars.js
+++ b/src/js/navbars.js
@@ -187,7 +187,6 @@ app.sizeNavbars = function (viewContainer) {
         var centerLeft = diff;
         if (app.rtl && noLeft && noRight && center.length > 0) centerLeft = -centerLeft;
         center.css({left: centerLeft + 'px'});
-
     });
 };
 


### PR DESCRIPTION
When you have a navbar with icon on left and subnavbar with icons on left and right - size of is set according to navbar. That causes subnavbar to go to left.

Always follow the [contribution guidelines](https://github.com/nolimits4web/Framework7/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. 
