### PR TITLE
获取url参数问题的修改

### DIFF
--- a/src/js/dom7-utils.js
+++ b/src/js/dom7-utils.js
@@ -1,12 +1,18 @@
 // DOM Library Utilites
 $.parseUrlQuery = function (url) {
+   var url = url || location.href;
     var query = {}, i, params, param;
-    if (url.indexOf('?') >= 0) url = url.split('?')[1];
-    else return query;
-    params = url.split('&');
-    for (i = 0; i < params.length; i++) {
-        param = params[i].split('=');
-        query[param[0]] = param[1];
+
+    if(typeof url === 'string' && url.length)  {
+        url = (url.indexOf('#') > -1) ? url.split('#')[0] : url;
+        if(url.indexOf('?') > -1) url = url.split('?')[1];
+        else return query;
+
+        params = url.split('&');
+        for(i = 0; i < params.length; i ++) {
+            param = params[i].split('=');
+            query[param[0]] = param[1];
+        }
     }
     return query;
 };


### PR DESCRIPTION
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/nolimits4web/Framework7/blob/master/.github/CONTRIBUTING.md) when submitting a pull request. 

修改函数Dom7.parseUrlQuery(url),的一个bug，当url传入的是http://www.baidu.com?name=li&age=18，这种格式的时候，返回的结果是没有问题的，但是当传入的url为http://www.baidu.com?name=li&age=18#tab1或者别的存在有hash的地址的时候，返回的结果就会出现问题，比如上面这的返回的地址query应该为{name: 'li', age: 18},但是返回的query为{name :'li', age: '18#tab1'};这种形式就不正确了
