### PR TITLE
Fixed buggy morph to popover animation for Chrome on Android

### DIFF
--- a/src/js/modals.js
+++ b/src/js/modals.js
@@ -372,7 +372,7 @@ app.popover = function (modal, target, removeOnClose) {
                         if (!target.hasClass('floating-button-to-popover-in')) return;
                         target
                             .addClass('floating-button-to-popover-scale')
-                            .transform('translate3d(' + diffX + 'px, ' + diffY + 'px,0) scale(' + (modalWidth/targetWidth) + ', ' + (modalHeight/targetHeight) + ')');
+                            .transform('translate3d(' + diffX + 'px, ' + diffY + 'px,0)');
                     });
 
                 modal.once('close', function () {

--- a/src/less/material/floating-button.less
+++ b/src/less/material/floating-button.less
@@ -123,31 +123,3 @@
         }
     }
 }
-
-// Popove Morph
-.floating-button-to-popover {
-    &.floating-button-to-popover {
-        .transition(300ms);
-    }
-    &.floating-button-to-popover-in {
-        .transition(100ms);
-        i {
-            opacity: 0;
-            .transition(100ms);
-        }
-    }
-    &.floating-button-to-popover-scale {
-        border-radius: 0;
-        .transition(300ms);
-        box-shadow: none;
-    }
-    &.floating-button-to-popover-out {
-        .delay(0ms);
-        .transition(300ms);
-        i {
-            opacity: 1;
-            .transition(100ms);
-            .delay(200ms);
-        }
-    }
-}

--- a/src/less/material/modals.less
+++ b/src/less/material/modals.less
@@ -287,21 +287,16 @@ input.modal-text-input {
     }
     &.popover-floating-button {
         .transform-origin(center center);
-        .transform(scale(0.7));
-        border-radius: 50%;
+        .transform(scale(0));
         box-shadow: none;
         .depth(3);
         &.modal-in {
-            border-radius: 0%;
             .transform(scale(1));
-            .delay(200ms);
-            .transition(200ms);
+            .transition(400ms);
         }
         &.modal-out {
-            border-radius: 50%;
-            .transform(scale(0.7));
-            .delay(0ms);
-            .transition(100ms);
+            .transform(scale(0));
+            .transition(200ms);
         }
         .list-block {
             margin: 0;

--- a/src/less/material/modals.less
+++ b/src/less/material/modals.less
@@ -450,18 +450,20 @@ html.with-statusbar-overlay {
     height: 260px;
     z-index: 12000;
     display: none;
-    -webkit-transition-property: -webkit-transform;
-    -moz-transition-property: -moz-transform;
-    -ms-transition-property: -ms-transform;
-    -o-transition-property: -o-transform;
-    transition-property: transform;
+    -webkit-transition-property: -webkit-transform, opacity;
+    -moz-transition-property: -moz-transform, opacity;
+    -ms-transition-property: -ms-transform, opacity;
+    -o-transition-property: -o-transform, opacity;
+    transition-property: transform, opacity;
     background: #fff;
+    opacity: 0;
     .translate3d(0,100%,0);
     &.modal-in, &.modal-out {
         .transition(400ms);
     }
     &.modal-in {
         .translate3d(0,0,0);
+        opacity: 1;
     }
     &.modal-out {
         .translate3d(0,100%,0);


### PR DESCRIPTION
Fixed the bug with the morph to popover animation for Chrome on Android.
Fixes these issues: #1088, #885 

Here before & after video:
Before: [https://goo.gl/photos/pJzzFfaHcDGHbg2M9](https://goo.gl/photos/pJzzFfaHcDGHbg2M9)
After: [https://goo.gl/photos/sRbc773DzgNoBZsy6](https://goo.gl/photos/sRbc773DzgNoBZsy6)
