### PR TITLE
Fix material chips direction in RTL mode

### DIFF
--- a/src/less/material/framework7.material.rtl.less
+++ b/src/less/material/framework7.material.rtl.less
@@ -176,6 +176,25 @@ label.label-checkbox, label.label-radio {
     align-self: flex-start;
     .align-items(flex-start);
 }
+
+/* === Chips === */
+.chip{
+	.chip-media {
+		margin-left: 0;
+		margin-right: -12px;
+		+ .chip-label{
+			margin-left: 0px;
+			margin-right: 8px;
+		}
+	}
+    .chip-label {
+        + .chip-delete {
+		margin-left: 0px;
+		margin-right: 4px;
+        }
+    }	
+}
+
 /* === Accordion === */
 .list-block {
     .accordion-toggle {


### PR DESCRIPTION
Before in RTL the design look broken.

See codepen:
http://codepen.io/siton/pen/YGJVrK?editors=1100