### PR TITLE
Issue #1166: Ajax error callback is always called (after success callback) if I set timeout option

### DIFF
--- a/src/js/dom7-ajax.js
+++ b/src/js/dom7-ajax.js
@@ -241,10 +241,6 @@ $.ajax = function (options) {
     fireAjaxCallback('ajaxStart', {xhr: xhr}, 'start', xhr);
     fireAjaxCallback(undefined, undefined, 'beforeSend', xhr);
 
-
-    // Send XHR
-    xhr.send(postData);
-
     // Timeout
     if (options.timeout > 0) {
         xhr.onabort = function () {
@@ -256,6 +252,9 @@ $.ajax = function (options) {
             fireAjaxCallback('ajaxComplete', {xhr: xhr, timeout: true}, 'complete', xhr, 'timeout');
         }, options.timeout);
     }
+
+    // Send XHR
+    xhr.send(postData);
 
     // Return XHR object
     return xhr;


### PR DESCRIPTION
This is a bug fix for issue #1166. User @IvanPaiano was send a synchronous POST with a timeout. They way the code was written is the send would happen first, block for a result, fire the success callback and then the timeout would be created. 10 seconds later the timeout would fire and the error callback would be invoked.

This wouldn't happen with an async call (or at least would be less likely) as the xhr.send() call is not blocking.

The fix is pretty simple, move xhr.send() to after the setup of the timeout.
