### PR TITLE
Ios filled buttons vertical-align problem fixed.

### DIFF
--- a/src/less/ios/forms.less
+++ b/src/less/ios/forms.less
@@ -190,7 +190,7 @@ html.android {
     &.button-fill {
         color:#fff;
         background: @themeColor;
-        border: none;
+        border-color: transparent;
         html:not(.watch-active-state) &:active, &.active-state {
             opacity: 0.8;
         }


### PR DESCRIPTION
Ios buttons have 2px lover line-height from height. I think it's because of borders (1px top, 1px bottom). When we set border:none; to filled buttons its cause vertical align problem. 

Using border-color: transparent instead of border: none; solves problem.
