### PR TITLE
Empty fields should also be submitted

### DIFF
--- a/dist/js/framework7.js
+++ b/dist/js/framework7.js
@@ -12511,7 +12511,7 @@
                         toPush = $.serializeObject(obj[prop], newParents);
                         if (toPush !== '') resultArray.push(toPush);
                     }
-                    else if (typeof obj[prop] !== 'undefined' && obj[prop] !== '') {
+                    else if (typeof obj[prop] !== 'undefined') {
                         // Should be string or plain value
                         resultArray.push(var_name(prop) + '=' + var_value(obj[prop]));
                     }


### PR DESCRIPTION
When form is submitted empty field should also be send to server so that for example binding system like (spring bind) is aware of empty value.

Now request looks like:
paymentAction=NEXT&currentStep=1&type=posepa&paymentType=326&docId=BFKKSI2210000002Q3J5XRBA

After fix we also see empty value(s):
paymentAction=NEXT&currentStep=1&type=posepa&paymentType=326&city=&docId=BFKKSI2210000002Q3J5XRBA