### PR TITLE
Framework7 Ajax Method: Posting json data which contains "&" sign.

### DIFF
--- a/dist/js/framework7.js
+++ b/dist/js/framework7.js
@@ -12200,7 +12200,7 @@
                             postData = '--' + boundary + '\r\n' + _newData.join('--' + boundary + '\r\n') + '--' + boundary + '--\r\n';
                         }
                         else {
-                            postData = options.contentType === 'application/x-www-form-urlencoded' ? _data : _data.replace(/&/g, '%26');
+                            postData = _data;
                         }
                     }
                 }

--- a/dist/js/framework7.js
+++ b/dist/js/framework7.js
@@ -12200,7 +12200,7 @@
                             postData = '--' + boundary + '\r\n' + _newData.join('--' + boundary + '\r\n') + '--' + boundary + '--\r\n';
                         }
                         else {
-                            postData = options.contentType === 'application/x-www-form-urlencoded' ? _data : _data.replace(/&/g, '\r\n');
+                            postData = options.contentType === 'application/x-www-form-urlencoded' ? _data : _data.replace(/&/g, '%26');
                         }
                     }
                 }


### PR DESCRIPTION
Why are we replacing "&" with new line character on ajax json data?

_data.replace(/&/g, '\r\n');
This replace operation causes json error on the server. Why we need this replace operation?

## With current replace method:
```
var _data = "Tarih & Saat";
_data.replace(/&/g, '\r\n');
```

**Result**
> "Tarih
> Saat"

in JSON at position 927token
    at Object.parse (native)
    at parse (C:\Users\ibrahimyilmaz\workspace\appcreator\node_modules\body-parser\lib\types\json.js:88:17)