### PR TITLE
Added subtitle for navbar center

### DIFF
--- a/src/less/ios/toolbars.less
+++ b/src/less/ios/toolbars.less
@@ -105,6 +105,15 @@
         .flex-shrink(10);
         .flexbox();
         .align-items(center);
+        .subtitle {
+	        color: gray;
+	        display: block; 
+	        font-size: 10px;
+	        position: absolute;
+	        bottom: -14px;
+	        text-align: center;
+	        width: 100%;
+        }
     }
     .left, .right {
         .flex-shrink(0);


### PR DESCRIPTION
Added subtitle for navbar center in iOS
Like in whatsup for example

![Picture](https://cloud.githubusercontent.com/assets/1151237/20889689/dd690b1e-bafb-11e6-8642-61400bc6acae.png)
