### PR TITLE
Fixed issue with empty Material Tabbar.

### DIFF
--- a/src/js/material-tabbar.js
+++ b/src/js/material-tabbar.js
@@ -5,19 +5,21 @@ app.materialTabbarSetHighlight = function (tabbar, activeLink) {
     tabbar = $(tabbar);
     activeLink = activeLink || tabbar.find('.tab-link.active');
 
-    var tabLinkWidth, highlightTranslate;
-    if (tabbar.hasClass('tabbar-scrollable')) {
-        tabLinkWidth = activeLink[0].offsetWidth + 'px';
-        highlightTranslate = (app.rtl ? - activeLink[0].offsetLeft: activeLink[0].offsetLeft) + 'px';
-    }
-    else {
-        tabLinkWidth = 1 / tabbar.find('.tab-link').length * 100 + '%';
-        highlightTranslate = (app.rtl ? - activeLink.index(): activeLink.index()) * 100 + '%';
-    }
+    if (activeLink && activeLink.length > 0) {
+        var tabLinkWidth, highlightTranslate;
+        if (tabbar.hasClass('tabbar-scrollable')) {
+            tabLinkWidth = activeLink[0].offsetWidth + 'px';
+            highlightTranslate = (app.rtl ? - activeLink[0].offsetLeft: activeLink[0].offsetLeft) + 'px';
+        }
+        else {
+            tabLinkWidth = 1 / tabbar.find('.tab-link').length * 100 + '%';
+            highlightTranslate = (app.rtl ? - activeLink.index(): activeLink.index()) * 100 + '%';
+        }
 
-    tabbar.find('.tab-link-highlight')
-        .css({width: tabLinkWidth})
-        .transform('translate3d(' + highlightTranslate + ',0,0)');
+        tabbar.find('.tab-link-highlight')
+            .css({width: tabLinkWidth})
+            .transform('translate3d(' + highlightTranslate + ',0,0)');
+    }
 };
 app.initPageMaterialTabbar = function (pageContainer) {
     pageContainer = $(pageContainer);


### PR DESCRIPTION
If we use the Material Tabbar and set it to scrollable, but the Tabbar itself is empty, an error will occur because the active tab bar does not exist. This fix should prevent Framework7 from throwing an exception and continue to work as expected.