### PR TITLE
make parseQueryUrl more compatibility

### DIFF
--- a/src/js/dom7-utils.js
+++ b/src/js/dom7-utils.js
@@ -1,4 +1,8 @@
 // DOM Library Utilites
+/**
+ * searchStr: the url need to be parse
+ * name: the key in parse object , defalut empty
+ */
 $.parseUrlQuery= function (searchStr, name) {
     var qObj = {};
     var searchStr = searchStr || location.href;

--- a/src/js/dom7-utils.js
+++ b/src/js/dom7-utils.js
@@ -1,21 +1,19 @@
 // DOM Library Utilites
-$.parseUrlQuery = function (url) {
-   var url = url || location.href;
-    var query = {}, i, params, param;
+$.parseUrlQuery= function (searchStr, name) {
+    var qObj = {};
+    var searchStr = searchStr || location.href;
+    searchStr = searchStr.indexOf('?')>-1 ? searchStr.replace(/\S*\?/,'') : '';
+    if (searchStr) {
+        var params = searchStr.split('&'),
+            length = params.length, a;
 
-    if (typeof url === 'string' && url.length)  {
-        url = (url.indexOf('#') > -1) ? url.split('#')[0] : url;
-        if (url.indexOf('?') > -1) url = url.split('?')[1];
-        else return query;
-
-        params = url.split('&');
-        for (i = 0; i < params.length; i ++) {
-            param = params[i].split('=');
-            query[param[0]] = param[1];
+        for (var i = 0; i < length; i++) {
+            a = params[i].replace(/#\S+/g,'').split('=');
+            qObj[decodeURIComponent(a[0])] = decodeURIComponent(a[1] || '');
         }
     }
-    return query;
-};
+    return name ? qObj[name] : qObj;
+},
 $.isArray = function (arr) {
     if (Object.prototype.toString.apply(arr) === '[object Array]') return true;
     else return false;

--- a/src/js/dom7-utils.js
+++ b/src/js/dom7-utils.js
@@ -1,7 +1,7 @@
 // DOM Library Utilites
 
 $.parseUrlQuery= function (url) {
-    var url = url || location.href;
+    var url = decodeURIComponent(url || location.href);
     var query = {},i, params, param, length;
     if (typeof url === 'string' && url.length)  {
         url = url.indexOf('?')>-1 ? url.replace(/\S*\?/,'') : '';
@@ -9,7 +9,7 @@ $.parseUrlQuery= function (url) {
 
         for (i = 0; i < length; i++) {
             param = params[i].replace(/#\S+/g,'').split('=');
-            query[decodeURIComponent(param[0])] = decodeURIComponent(param[1] || '');
+            query[(param[0])] = param[1] || '';
         }
     }
 

--- a/src/js/dom7-utils.js
+++ b/src/js/dom7-utils.js
@@ -1,22 +1,19 @@
 // DOM Library Utilites
-/**
- * searchStr: the url need to be parse
- * name: the key in parse object , defalut empty
- */
-$.parseUrlQuery= function (searchStr, name) {
-    var qObj = {};
-    var searchStr = searchStr || location.href;
-    searchStr = searchStr.indexOf('?')>-1 ? searchStr.replace(/\S*\?/,'') : '';
-    if (searchStr) {
-        var params = searchStr.split('&'),
-            length = params.length, a;
 
-        for (var i = 0; i < length; i++) {
-            a = params[i].replace(/#\S+/g,'').split('=');
-            qObj[decodeURIComponent(a[0])] = decodeURIComponent(a[1] || '');
+$.parseUrlQuery= function (url) {
+    var url = url || location.href;
+    var query = {},i, params, param, length;
+    if (typeof url === 'string' && url.length)  {
+        url = url.indexOf('?')>-1 ? url.replace(/\S*\?/,'') : '';
+        params = url.split('&'), length = params.length;
+
+        for (i = 0; i < length; i++) {
+            param = params[i].replace(/#\S+/g,'').split('=');
+            query[decodeURIComponent(param[0])] = decodeURIComponent(param[1] || '');
         }
     }
-    return name ? qObj[name] : qObj;
+
+    return query;
 },
 $.isArray = function (arr) {
     if (Object.prototype.toString.apply(arr) === '[object Array]') return true;


### PR DESCRIPTION
when i update the framework7 to the version 1.5.2, i found the parseQueryUrl has been changed. I learn this change for fix the hash status.('http://www.baidu.com?name=li&age=18#tab1').
**But for a normal occasion,** when i set the pushState=true in app init, all my url will become this style (http://127.0.0.1:8080/#!/views/test-query.html?abc=333)， the parseQueryUrl can't get any params. so i do this request, and this change will fix more occasion.

1. can parse the hash status, such as **http://www.ttt.com?name=li&age=18#tab1**
2. fix the push status true status, such as **http://127.0.0.1:8080/#!/views/test-query.html?abc=333**
3.when parseQueryUrl without params ,it will get the location.href as default.