### PR TITLE
Fixed issue with missing context when router went back.

### DIFF
--- a/src/js/router.js
+++ b/src/js/router.js
@@ -1088,6 +1088,7 @@ app.router.back = function (view, options) {
     function proceed(content) {
         app.router.preprocess(view, content, url, function (content) {
             options.content = content;
+            options.context = view.contextCache[options.url];
             app.router._back(view, options);
         });
     }


### PR DESCRIPTION
This fixes issue #897 when there are multiple pages in the history and the router went back one page, it will then preload the second last page in the history but without setting the context. I have used the contextCache to restore the context of that page. Please review and merge if it looks good. It works for me.