### PR TITLE
Add support for a data-display-as attribute that specifies an alternate display value for select options

### DIFF
--- a/src/js/smart-select.js
+++ b/src/js/smart-select.js
@@ -23,7 +23,13 @@ app.initSmartSelects = function (pageContainer) {
 
         var valueText = [];
         for (var i = 0; i < select.length; i++) {
-            if (select[i].selected) valueText.push(select[i].textContent.trim());
+            if (select[i].selected) {
+                if (typeof select[i].dataset.displayAs !== 'undefined') {
+					valueText.push(select[i].dataset.displayAs.trim());
+				} else {
+					valueText.push(select[i].textContent.trim());
+				}
+			}
         }
 
         var itemAfter = smartSelect.find('.item-after');
@@ -44,7 +50,13 @@ app.initSmartSelects = function (pageContainer) {
         $select.on('change', function () {
             var valueText = [];
             for (var i = 0; i < select.length; i++) {
-                if (select[i].selected) valueText.push(select[i].textContent.trim());
+                if (select[i].selected) {
+                	if (typeof select[i].dataset.displayAs !== 'undefined') {
+						valueText.push(select[i].dataset.displayAs.trim());
+					} else {
+						valueText.push(select[i].textContent.trim());
+					}
+				}
             }
             smartSelect.find('.item-after').text(valueText.join(', '));
         });
@@ -407,18 +419,20 @@ app.smartSelectOpen = function (smartSelect, reLayout) {
             });
         }
         container.on('change', 'input[name="' + inputName + '"]', function () {
+			var option, text;
             var input = this;
             var value = input.value;
             var optionText = [];
             if (input.type === 'checkbox') {
                 var values = [];
                 for (var i = 0; i < select.options.length; i++) {
-                    var option = select.options[i];
+                    option = select.options[i];
                     if (option.value === value) {
                         option.selected = input.checked;
                     }
                     if (option.selected) {
-                        optionText.push(option.textContent.trim());
+                        text = typeof option.dataset.displayAs !== 'undefined' ? option.dataset.displayAs : option.textContent;
+                        optionText.push(text.trim());
                     }
                 }
                 if (maxLength) {
@@ -426,7 +440,9 @@ app.smartSelectOpen = function (smartSelect, reLayout) {
                 }
             }
             else {
-                optionText = [smartSelect.find('option[value="' + value + '"]').text()];
+                option = smartSelect.find('option[value="' + value + '"]')[0];
+                text = typeof option.dataset.displayAs !== 'undefined' ? option.dataset.displayAs : option.textContent;
+                optionText = [text];
                 select.value = value;
             }
 


### PR DESCRIPTION
These changes add support for a data-display-as attribute that specifies an alternate display value for select options.  For example, when setting an alarm on iOS when the user sets the repeat days, the select shows values like "Every Monday", but on the main alarm page the value is displayed as "Mon".

A smart select set up to work similarly with these F7 changes might be defined as:

```html
    <li>
     <a href="#" class="item-link smart-select">
      <select name="repeat" multiple>
       <option value="0" data-display-as="Sun">Every Sunday</option>
       <option value="1" data-display-as="Mon">Every Monday</option>
       <option value="2" data-display-as="Tue">Every Tuesday</option>
       <option value="3" data-display-as="Wed">Every Wednesday</option>
       <option value="4" data-display-as="Thu">Every Thursday</option>
       <option value="5" data-display-as="Fri">Every Friday</option>
       <option value="6" data-display-as="Sat">Every Saturday</option>
      </select>
      <div class="item-content">
       <div class="item-inner">
        <div class="item-title label">Repeat</div>
        <div class="item-after">VALUE</div>
       </div>
      </div>
     </a>
    </li>
```
