### PR TITLE
Remove prefixed properties and methods for Opera, Firefox and IE

### DIFF
--- a/src/js/dom7-methods.js
+++ b/src/js/dom7-methods.js
@@ -174,7 +174,7 @@ Dom7.prototype = {
     transform : function (transform) {
         for (var i = 0; i < this.length; i++) {
             var elStyle = this[i].style;
-            elStyle.webkitTransform = elStyle.MsTransform = elStyle.msTransform = elStyle.MozTransform = elStyle.OTransform = elStyle.transform = transform;
+            elStyle.webkitTransform = elStyle.transform = transform;
         }
         return this;
     },
@@ -184,7 +184,7 @@ Dom7.prototype = {
         }
         for (var i = 0; i < this.length; i++) {
             var elStyle = this[i].style;
-            elStyle.webkitTransitionDuration = elStyle.MsTransitionDuration = elStyle.msTransitionDuration = elStyle.MozTransitionDuration = elStyle.OTransitionDuration = elStyle.transitionDuration = duration;
+            elStyle.webkitTransitionDuration = elStyle.transitionDuration = duration;
         }
         return this;
     },
@@ -283,7 +283,7 @@ Dom7.prototype = {
         return this;
     },
     transitionEnd: function (callback) {
-        var events = ['webkitTransitionEnd', 'transitionend', 'oTransitionEnd', 'MSTransitionEnd', 'msTransitionEnd'],
+        var events = ['webkitTransitionEnd', 'transitionend'],
             i, dom = this;
         function fireCallBack(e) {
             /*jshint validthis:true */
@@ -301,7 +301,7 @@ Dom7.prototype = {
         return this;
     },
     animationEnd: function (callback) {
-        var events = ['webkitAnimationEnd', 'OAnimationEnd', 'MSAnimationEnd', 'animationend'],
+        var events = ['webkitAnimationEnd', 'animationend'],
             i, dom = this;
         function fireCallBack(e) {
             callback(e);
@@ -468,7 +468,6 @@ Dom7.prototype = {
         if (typeof selector === 'string') {
             if (el.matches) return el.matches(selector);
             else if (el.webkitMatchesSelector) return el.webkitMatchesSelector(selector);
-            else if (el.mozMatchesSelector) return el.mozMatchesSelector(selector);
             else if (el.msMatchesSelector) return el.msMatchesSelector(selector);
             else {
                 compareWith = $(selector);

--- a/src/js/dom7-utils.js
+++ b/src/js/dom7-utils.js
@@ -133,7 +133,7 @@ $.getTranslate = function (el, axis) {
         transformMatrix = new WebKitCSSMatrix(curTransform === 'none' ? '' : curTransform);
     }
     else {
-        transformMatrix = curStyle.MozTransform || curStyle.OTransform || curStyle.MsTransform || curStyle.msTransform  || curStyle.transform || curStyle.getPropertyValue('transform').replace('translate(', 'matrix(1, 0, 0, 1,');
+        transformMatrix = curStyle.transform || curStyle.getPropertyValue('transform').replace('translate(', 'matrix(1, 0, 0, 1,');
         matrix = transformMatrix.toString().split(',');
     }
 
@@ -166,7 +166,6 @@ $.getTranslate = function (el, axis) {
 $.requestAnimationFrame = function (callback) {
     if (window.requestAnimationFrame) return window.requestAnimationFrame(callback);
     else if (window.webkitRequestAnimationFrame) return window.webkitRequestAnimationFrame(callback);
-    else if (window.mozRequestAnimationFrame) return window.mozRequestAnimationFrame(callback);
     else {
         return window.setTimeout(callback, 1000 / 60);
     }
@@ -174,7 +173,6 @@ $.requestAnimationFrame = function (callback) {
 $.cancelAnimationFrame = function (id) {
     if (window.cancelAnimationFrame) return window.cancelAnimationFrame(id);
     else if (window.webkitCancelAnimationFrame) return window.webkitCancelAnimationFrame(id);
-    else if (window.mozCancelAnimationFrame) return window.mozCancelAnimationFrame(id);
     else {
         return window.clearTimeout(id);
     }  


### PR DESCRIPTION
As discussed in #1288 

This PR does:
* Removes *Transform properties accesses
* Removes *TransitionDuration properties accesses
* Removes *TransitionEnd events
* Removes *AnimationEnd events
* Removes mozRequestAnimationFrame and mozCancelAnimationFrame

The non prefixed and webkit prefixed methods/properties are kept

It keeps `msMatchesSelector` since even IE 11 and EDGE support only the prefixed method

Tested in Firefox, Chrome, IE11, and everything seems to be working