### PR TITLE
update .each() to emulate jQuery

### DIFF
--- a/src/js/dom7-methods.js
+++ b/src/js/dom7-methods.js
@@ -423,10 +423,19 @@ Dom7.prototype = {
     },
 
     //Dom manipulation
+    // Iterate over the collection passing elements to `callback`
     each: function (callback) {
+        // Don't bother continuing without a callback
+        if (!callback) return this;
+        // Iterate over the current collection
         for (var i = 0; i < this.length; i++) {
-            callback.call(this[i], i, this[i]);
+            // If the callback returns false
+            if (callback.call(this[i], i, this[i]) === false) {
+                // End the loop early
+                return this;
+            }
         }
+        // Return `this` to allow chained DOM operations
         return this;
     },
     filter: function (callback) {

--- a/src/js/dom7-utils.js
+++ b/src/js/dom7-utils.js
@@ -19,20 +19,34 @@ $.isArray = function (arr) {
     else return false;
 };
 $.each = function (obj, callback) {
+    // Check it's iterable
+    // TODO: Should probably raise a value error here
     if (typeof obj !== 'object') return;
+    // Don't bother continuing without a callback
     if (!callback) return;
-    var i, prop;
     if ($.isArray(obj) || obj instanceof Dom7) {
+        var i;
         // Array
         for (i = 0; i < obj.length; i++) {
-            callback(i, obj[i]);
+            // If callback returns false
+            if (callback(i, obj[i]) === false) {
+                // Break out of the loop
+                return;
+            }
         }
     }
     else {
+        var prop;
         // Object
         for (prop in obj) {
+            // Check the propertie belongs to the object
+            // not it's prototype
             if (obj.hasOwnProperty(prop)) {
-                callback(prop, obj[prop]);
+                // If the callback returns false
+                if (callback(prop, obj[prop]) === false) {
+                    // Break out of the loop;
+                    return;
+                }
             }
         }
     }


### PR DESCRIPTION
Update DOM7's `each()` method to function similar to jQuery (https://api.jquery.com/each/)

Allows callbacks to return false to end the iteration of the given array/object

Should fix #1305