### PR TITLE
Change .item-after class margin-left to auto, fixing list item right aligned content

### DIFF
--- a/src/less/ios/lists.less
+++ b/src/less/ios/lists.less
@@ -111,7 +111,7 @@
         white-space: nowrap;
         color: #8e8e93;
         .flex-shrink(0);
-        margin-left: 5px;
+        margin-left: auto;
         .flexbox();
         max-height: 28px;
     }

--- a/src/less/ios/lists.less
+++ b/src/less/ios/lists.less
@@ -112,6 +112,7 @@
         color: #8e8e93;
         .flex-shrink(0);
         margin-left: auto;
+        padding-left: 5px;
         .flexbox();
         max-height: 28px;
     }

--- a/src/less/material/lists.less
+++ b/src/less/material/lists.less
@@ -109,7 +109,7 @@
         white-space: nowrap;
         color: #757575;
         .flex-shrink(0);
-        margin-left: 8px;
+        margin-left: auto;
         .flexbox();
         max-height: 28px;
         font-size: 14px;

--- a/src/less/material/lists.less
+++ b/src/less/material/lists.less
@@ -110,6 +110,7 @@
         color: #757575;
         .flex-shrink(0);
         margin-left: auto;
+        padding-left: 8px;
         .flexbox();
         max-height: 28px;
         font-size: 14px;


### PR DESCRIPTION
It changes margin-left to auto so list view items with right  aligned content is properly aligned in non webkit browsers. See rationale at https://medium.com/@samserif/flexbox-s-best-kept-secret-bd3d892826b6#.bi13yuk7i

Fixes #1314 

Tested with Firefox, Chrome, IE, EDGE