### PR TITLE
Add panel overlay click event

### DIFF
--- a/src/js/framework7/clicks.js
+++ b/src/js/framework7/clicks.js
@@ -96,14 +96,18 @@ app.initClickEvents = function () {
                 else app.openPanel('left');
             }
         }
+        
         // Close Panel
         if (clicked.hasClass('close-panel')) {
             app.closePanel();
         }
 
-        if (clicked.hasClass('panel-overlay') && app.params.panelsCloseByOutside) {
-            app.closePanel();
+        // Panel Overlay
+        if (clicked.hasClass('panel-overlay')) {
+            $('.panel.active').trigger('panel:overlay-click');
+            if (app.params.panelsCloseByOutside) app.closePanel();
         }
+
         // Popover
         if (clicked.hasClass('open-popover')) {
             var popover;


### PR DESCRIPTION
When the panel overlay is clicked, trigger a panel overlay click event on the currently open panel. This change was required to support this [PR in Framework7 Vue](https://github.com/nolimits4web/Framework7-Vue/pull/93).