### PR TITLE
Only include first level list elements in sortable

### DIFF
--- a/src/js/framework7/sortable.js
+++ b/src/js/framework7/sortable.js
@@ -37,7 +37,7 @@ app.initSortable = function () {
         /*jshint validthis:true */
         sortingEl = $(this).parent();
         startIndex = sortingEl.index();
-        sortingItems = sortingEl.parent().find('li');
+        sortingItems = sortingEl.parent().children('li');
         sortableContainer = sortingEl.parents('.sortable');
         e.preventDefault();
         app.allowPanelOpen = app.allowSwipeout = false;


### PR DESCRIPTION
If an li in a sortable's ul contains li elements within, sortable tries to sort the parent li (or a different li entirely) within the child li. Fixes bug by only looking one level down for li elements.