### PR TITLE
:sparkles: Issue #1364: Theme color is missing for .statusbar-overlay

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -39,6 +39,7 @@
             "material" : [
                 "src/less/material/_mixins.less",
                 "src/less/material/_colors-vars.less",
+                "src/less/material/_dark-colors-vars.less",
                 "src/less/material/intro.less",
                 "src/less/material/grid.less",
                 "src/less/material/views.less",

--- a/src/less/material/_dark-colors-vars.less
+++ b/src/less/material/_dark-colors-vars.less
@@ -1,0 +1,22 @@
+@darkred: #B71C1C;
+@darkpink: #880E4F;
+@darkpurple: #4A148C;
+@darkdeeppurple:#311B92;
+@darkindigo: #1A237E;
+@darkblue: #0D47A1;
+@darklightblue: #01579B;
+@darkcyan: #006064;
+@darkteal: #004D40;
+@darkgreen: #1B5E20;
+@darklightgreen: #33691E;
+@darklime: #827717;
+@darkyellow: #F57F17;
+@darkamber: #FF6F00;
+@darkorange: #E65100;
+@darkdeeporange: #BF360C;
+@darkbrown: #3E2723;
+@darkgray: #212121;
+@darkbluegray: #263238;
+
+// Theme Color
+@darkThemeColor: @darkblue;

--- a/src/less/material/framework7.material.colors.less
+++ b/src/less/material/framework7.material.colors.less
@@ -1,5 +1,6 @@
 @import url('_mixins.less');
 @import url('_colors-vars.less');
+@import url('_dark-colors-vars.less');
 /*==========================
 Framework7 Layouts Themes
 ==========================*/
@@ -168,7 +169,7 @@ Framework7 Layouts Themes
 /*==========================
 Framework7 Color Themes
 ==========================*/
-.theme-mixin(@colorName, @color, @pressColor) {
+.theme-mixin(@colorName, @color, @pressColor, @darkcolor) {
     //Buttons
     .button {
         .theme-@{colorName} & {
@@ -318,6 +319,10 @@ Framework7 Color Themes
         .timeline-year-title, .timeline-month-title {
             background-color: @color;
         }
+        // Status Bar Overlay
+        .statusbar-overlay {
+            background-color: @darkcolor;
+        }
     }
     .swiper-pagination {
         &.color-@{colorName}, .theme-@{colorName} & {
@@ -382,27 +387,27 @@ Framework7 Color Themes
         color: #fff;
     }
 }
-.theme-mixin(e('red'), @red, #D32F2F);
-.theme-mixin(e('pink'), @pink, #C2185B);
-.theme-mixin(e('purple'), @purple, #7B1FA2);
-.theme-mixin(e('deeppurple'), @deeppurple, #512DA8);
-.theme-mixin(e('indigo'), @indigo, #303F9F);
-.theme-mixin(e('blue'), @blue, #1976D2);
-.theme-mixin(e('lightblue'), @lightblue, #0288D1);
-.theme-mixin(e('cyan'), @cyan, #0097A7);
-.theme-mixin(e('teal'), @teal, #00897B);
-.theme-mixin(e('green'), @green, #388E3C);
-.theme-mixin(e('lightgreen'), @lightgreen, #689F38);
-.theme-mixin(e('lime'), @lime, #AFB42B);
-.theme-mixin(e('yellow'), @yellow, #FBC02D);
-.theme-mixin(e('amber'), @amber, #FFA000);
-.theme-mixin(e('orange'), @orange, #F57C00);
-.theme-mixin(e('deeporange'), @deeporange, #E64A19);
-.theme-mixin(e('brown'), @brown, #5D4037);
-.theme-mixin(e('gray'), @gray, #616161);
-.theme-mixin(e('bluegray'), @bluegray, #455A64);
-.theme-mixin(e('white'), @white, rgba(0,0,0,0.1));
-.theme-mixin(e('black'), @black, #333);
+.theme-mixin(e('red'), @red, #D32F2F, @darkred);
+.theme-mixin(e('pink'), @pink, #C2185B, @darkpink);
+.theme-mixin(e('purple'), @purple, #7B1FA2, @darkpurple);
+.theme-mixin(e('deeppurple'), @deeppurple, #512DA8, @darkdeeppurple);
+.theme-mixin(e('indigo'), @indigo, #303F9F, @darkindigo);
+.theme-mixin(e('blue'), @blue, #1976D2, @darkblue);
+.theme-mixin(e('lightblue'), @lightblue, #0288D1, @darklightblue);
+.theme-mixin(e('cyan'), @cyan, #0097A7, @darkcyan);
+.theme-mixin(e('teal'), @teal, #00897B, @darkteal);
+.theme-mixin(e('green'), @green, #388E3C, @darkgreen);
+.theme-mixin(e('lightgreen'), @lightgreen, #689F38, @darklightgreen);
+.theme-mixin(e('lime'), @lime, #AFB42B, @darklime);
+.theme-mixin(e('yellow'), @yellow, #FBC02D, @darkyellow);
+.theme-mixin(e('amber'), @amber, #FFA000, @darkamber);
+.theme-mixin(e('orange'), @orange, #F57C00, @darkorange);
+.theme-mixin(e('deeporange'), @deeporange, #E64A19, @darkdeeporange);
+.theme-mixin(e('brown'), @brown, #5D4037, @darkbrown);
+.theme-mixin(e('gray'), @gray, #616161, @gray);
+.theme-mixin(e('bluegray'), @bluegray, #455A64, @darkbluegray);
+.theme-mixin(e('white'), @white, rgba(0,0,0,0.1), @white);
+.theme-mixin(e('black'), @black, #333, @black);
 
 /*==========================
 Framework7 Color + Bg + Border

--- a/src/less/material/framework7.material.less
+++ b/src/less/material/framework7.material.less
@@ -1,5 +1,6 @@
 @import url('_mixins.less');
 @import url('_colors-vars.less');
+@import url('_dark-colors-vars.less');
 @import url('intro.less');
 @import url('grid.less');
 @import url('views.less');

--- a/src/less/material/framework7.material.rtl.less
+++ b/src/less/material/framework7.material.rtl.less
@@ -1,5 +1,6 @@
 @import url('_mixins.less');
 @import url('_colors-vars.less');
+@import url('_dark-colors-vars.less');
 /*=============
   Framework 7 RTL Additions
 =============*/
@@ -32,7 +33,7 @@ html {
         }
         & + .item-inner {
             margin-left: 0;
-            margin-right: 16px;    
+            margin-right: 16px;
         }
     }
     .item-link {
@@ -135,7 +136,7 @@ html {
 .range-slider {
     input[type="range"]::-webkit-slider-thumb:before {
         right: auto;
-        left: 100%;        
+        left: 100%;
     }
 }
 
@@ -217,7 +218,7 @@ label.label-checkbox, label.label-radio {
             .encoded-svg-background("<svg viewBox='0 0 60 120' xmlns='http://www.w3.org/2000/svg'><path d='m60 61.5-38.25 38.25-9.75-9.75 29.25-28.5-29.25-28.5 9.75-9.75z' fill='#c7c7cc' transform='translate(60,120) rotate(180)'/></svg>");
         }
     }
-    &:not(.media-list) .accordion-item-expanded:not(.media-item) .accordion-item-toggle .item-inner, 
+    &:not(.media-list) .accordion-item-expanded:not(.media-item) .accordion-item-toggle .item-inner,
     &:not(.media-list) .accordion-item-expanded:not(.media-item) > .item-link .item-inner,
     &.media-list .accordion-item-expanded .accordion-item-toggle .item-title-row,
     &.media-list .accordion-item-expanded > .item-link .item-title-row,

--- a/src/less/material/statusbar.less
+++ b/src/less/material/statusbar.less
@@ -10,7 +10,7 @@ html.with-statusbar-overlay .framework7-root {
     }
 }
 .statusbar-overlay {
-    background: @themeColor;
+    background: @darkThemeColor;
     z-index: 10000; // A bit lower than .modals-overlay
     position: absolute;
     left: 0;


### PR DESCRIPTION
The statusbar-overlay was stuck at blue even when you switch the theme color so I added in a rule for the statusbar-overlay class when the theme color changes. 

I also added in a bunch of dark colors for material as per the [Material color palette swatches](https://material.io/guidelines/style/color.html#color-color-palette). Using the 900 value for the dark color as the 500 value is the current theme color.

The dark color was added as per the [Material spec](https://developer.android.com/training/material/theme.html#StatusBar) as it specifies using the dark color for the statusbar overlay.