### PR TITLE
Change touch event listeners from passive to active to fix Chrome bug

### DIFF
--- a/src/js/framework7/calendar.js
+++ b/src/js/framework7/calendar.js
@@ -344,11 +344,10 @@ var Calendar = function (params) {
         p.container.find('.picker-calendar-prev-year').on('click', p.prevYear);
         p.container.find('.picker-calendar-next-year').on('click', p.nextYear);
         p.wrapper.on('click', handleDayClick);
-        var passiveListener = app.touchEvents.start === 'touchstart' && app.support.passiveListener ? {passive: true, capture: false} : false;
         if (p.params.touchMove) {
-            p.wrapper.on(app.touchEvents.start, handleTouchStart, passiveListener);
-            p.wrapper.on(app.touchEvents.move, handleTouchMove);
-            p.wrapper.on(app.touchEvents.end, handleTouchEnd, passiveListener);
+            p.wrapper.on(app.touchEvents.start, handleTouchStart, {passive: false});
+            p.wrapper.on(app.touchEvents.move, handleTouchMove, {passive: false});
+            p.wrapper.on(app.touchEvents.end, handleTouchEnd, {passive: false});
         }
 
         p.container[0].f7DestroyCalendarEvents = function () {
@@ -358,9 +357,9 @@ var Calendar = function (params) {
             p.container.find('.picker-calendar-next-year').off('click', p.nextYear);
             p.wrapper.off('click', handleDayClick);
             if (p.params.touchMove) {
-                p.wrapper.off(app.touchEvents.start, handleTouchStart, passiveListener);
-                p.wrapper.off(app.touchEvents.move, handleTouchMove);
-                p.wrapper.off(app.touchEvents.end, handleTouchEnd, passiveListener);
+                p.wrapper.off(app.touchEvents.start, handleTouchStart, {passive: false});
+                p.wrapper.off(app.touchEvents.move, handleTouchMove, {passive: false});
+                p.wrapper.off(app.touchEvents.end, handleTouchEnd, {passive: false});
             }
         };
 

--- a/src/js/framework7/clicks.js
+++ b/src/js/framework7/clicks.js
@@ -335,6 +335,6 @@ app.initClickEvents = function () {
         e.preventDefault();
     }
     if (app.support.touch && !app.device.android) {
-        $(document).on((app.params.fastClicks ? 'touchstart' : 'touchmove'), '.panel-overlay, .modal-overlay, .preloader-indicator-overlay, .popup-overlay, .searchbar-overlay', preventScrolling);
+        $(document).on((app.params.fastClicks ? 'touchstart' : 'touchmove'), '.panel-overlay, .modal-overlay, .preloader-indicator-overlay, .popup-overlay, .searchbar-overlay', preventScrolling, {passive: false});
     }
 };

--- a/src/js/framework7/panels.js
+++ b/src/js/framework7/panels.js
@@ -356,8 +356,7 @@ app.initSwipePanels = function () {
         panel.transition('').transform('');
         panelOverlay.css({display: ''}).transform('').transition('').css('opacity', '');
     }
-    var passiveListener = app.touchEvents.start === 'touchstart' && app.support.passiveListener ? {passive: true, capture: false} : false;
-    $(document).on(app.touchEvents.start, handleTouchStart, passiveListener);
-    $(document).on(app.touchEvents.move, handleTouchMove);
-    $(document).on(app.touchEvents.end, handleTouchEnd, passiveListener);
+    $(document).on(app.touchEvents.start, handleTouchStart, {passive: false});
+    $(document).on(app.touchEvents.move, handleTouchMove, {passive: false});
+    $(document).on(app.touchEvents.end, handleTouchEnd, {passive: false});
 };

--- a/src/js/framework7/picker.js
+++ b/src/js/framework7/picker.js
@@ -377,9 +377,9 @@ var Picker = function (params) {
 
         col.initEvents = function (detach) {
             var method = detach ? 'off' : 'on';
-            col.container[method](app.touchEvents.start, handleTouchStart);
-            col.container[method](app.touchEvents.move, handleTouchMove);
-            col.container[method](app.touchEvents.end, handleTouchEnd);
+            col.container[method](app.touchEvents.start, handleTouchStart, {passive: false});
+            col.container[method](app.touchEvents.move, handleTouchMove, {passive: false});
+            col.container[method](app.touchEvents.end, handleTouchEnd, {passive: false});
             col.items[method]('click', handleClick);
         };
         col.destroyEvents = function () {

--- a/src/js/framework7/pull-to-refresh.js
+++ b/src/js/framework7/pull-to-refresh.js
@@ -172,17 +172,16 @@ app.initPullToRefresh = function (pageContainer) {
     }
 
     // Attach Events
-    var passiveListener = app.touchEvents.start === 'touchstart' && app.support.passiveListener ? {passive: true, capture: false} : false;
-    eventsTarget.on(app.touchEvents.start, handleTouchStart, passiveListener);
-    eventsTarget.on(app.touchEvents.move, handleTouchMove);
-    eventsTarget.on(app.touchEvents.end, handleTouchEnd, passiveListener);
+    eventsTarget.on(app.touchEvents.start, handleTouchStart, {passive: false});
+    eventsTarget.on(app.touchEvents.move, handleTouchMove, {passive: false});
+    eventsTarget.on(app.touchEvents.end, handleTouchEnd, {passive: false});
 
     // Detach Events on page remove
     if (page.length === 0) return;
     function destroyPullToRefresh() {
-        eventsTarget.off(app.touchEvents.start, handleTouchStart);
-        eventsTarget.off(app.touchEvents.move, handleTouchMove);
-        eventsTarget.off(app.touchEvents.end, handleTouchEnd);
+        eventsTarget.off(app.touchEvents.start, handleTouchStart, {passive: false});
+        eventsTarget.off(app.touchEvents.move, handleTouchMove, {passive: false});
+        eventsTarget.off(app.touchEvents.end, handleTouchEnd, {passive: false});
     }
     eventsTarget[0].f7DestroyPullToRefresh = destroyPullToRefresh;
     function detachEvents() {

--- a/src/js/framework7/sortable.js
+++ b/src/js/framework7/sortable.js
@@ -117,13 +117,13 @@ app.initSortable = function () {
         isTouched = false;
         isMoved = false;
     }
-    $(document).on(app.touchEvents.start, '.list-block.sortable .sortable-handler', handleTouchStart);
+    $(document).on(app.touchEvents.start, '.list-block.sortable .sortable-handler', handleTouchStart, {passive: false});
     if (app.support.touch) {
-        $(document).on(app.touchEvents.move, '.list-block.sortable .sortable-handler', handleTouchMove);
-        $(document).on(app.touchEvents.end, '.list-block.sortable .sortable-handler', handleTouchEnd);
+        $(document).on(app.touchEvents.move, '.list-block.sortable .sortable-handler', handleTouchMove, {passive: false});
+        $(document).on(app.touchEvents.end, '.list-block.sortable .sortable-handler', handleTouchEnd, {passive: false});
     }
     else {
-        $(document).on(app.touchEvents.move, handleTouchMove);
-        $(document).on(app.touchEvents.end, handleTouchEnd);
+        $(document).on(app.touchEvents.move, handleTouchMove, {passive: false});
+        $(document).on(app.touchEvents.end, handleTouchEnd, {passive: false});
     }
 };

--- a/src/js/framework7/swipeout.js
+++ b/src/js/framework7/swipeout.js
@@ -280,14 +280,14 @@ app.initSwipeout = function (swipeoutEl) {
         });
     }
     if (swipeoutEl) {
-        $(swipeoutEl).on(app.touchEvents.start, handleTouchStart);
-        $(swipeoutEl).on(app.touchEvents.move, handleTouchMove);
-        $(swipeoutEl).on(app.touchEvents.end, handleTouchEnd);
+        $(swipeoutEl).on(app.touchEvents.start, handleTouchStart, {passive: false});
+        $(swipeoutEl).on(app.touchEvents.move, handleTouchMove, {passive: false});
+        $(swipeoutEl).on(app.touchEvents.end, handleTouchEnd, {passive: false});
     }
     else {
-        $(document).on(app.touchEvents.start, '.list-block li.swipeout', handleTouchStart);
-        $(document).on(app.touchEvents.move, '.list-block li.swipeout', handleTouchMove);
-        $(document).on(app.touchEvents.end, '.list-block li.swipeout', handleTouchEnd);
+        $(document).on(app.touchEvents.start, '.list-block li.swipeout', handleTouchStart, {passive: false});
+        $(document).on(app.touchEvents.move, '.list-block li.swipeout', handleTouchMove, {passive: false});
+        $(document).on(app.touchEvents.end, '.list-block li.swipeout', handleTouchEnd, {passive: false});
     }
         
 };

--- a/src/js/framework7/views.js
+++ b/src/js/framework7/views.js
@@ -435,10 +435,9 @@ var View = function (selector, params) {
     };
     view.attachEvents = function (detach) {
         var action = detach ? 'off' : 'on';
-        var passiveListener = app.touchEvents.start === 'touchstart' && app.support.passiveListener ? {passive: true, capture: false} : false;
-        container[action](app.touchEvents.start, view.handleTouchStart, passiveListener);
-        container[action](app.touchEvents.move, view.handleTouchMove);
-        container[action](app.touchEvents.end, view.handleTouchEnd, passiveListener);
+        container[action](app.touchEvents.start, view.handleTouchStart, {passive: false});
+        container[action](app.touchEvents.move, view.handleTouchMove, {passive: false});
+        container[action](app.touchEvents.end, view.handleTouchEnd, {passive: false});
     };
     view.detachEvents = function () {
         view.attachEvents(true);


### PR DESCRIPTION
Passive touch event listeners have been changed from passive to active to fix mobile Chrome version >= 56 not preventing default.
Mobile Chrome version >= 56 makes event listeners passive by default.

We've detected the bug while using the sortable.

See:
[https://www.chromestatus.com/features/5093566007214080](https://www.chromestatus.com/features/5093566007214080)