### PR TITLE
Add "clear N items", "select all" button to smart selects.

### DIFF
--- a/kitchen-sink-ios/forms-selects.html
+++ b/kitchen-sink-ios/forms-selects.html
@@ -67,6 +67,122 @@
               </div></a></li>
         </ul>
       </div>
+      <div class="content-block">Smart selects loaded in a popup</div>
+      <div class="list-block">
+        <ul>
+          <li><a href="#" data-open-in="popup" class="item-link smart-select">
+              <select name="fruits">
+                <option value="apple" selected="selected">Apple</option>
+                <option value="pineapple">Pineapple</option>
+                <option value="pear">Pear</option>
+                <option value="orange">Orange</option>
+                <option value="melon">Melon</option>
+                <option value="peach">Peach</option>
+                <option value="banana">Banana</option>
+              </select>
+              <div class="item-content">
+                <div class="item-inner">
+                  <div class="item-title">Fruit</div>
+                </div>
+              </div></a></li>
+          <li><a href="#" data-open-in="popup" data-popup-close-text="Close Cars" data-searchbar="true" data-searchbar-placeholder="Search cars" class="item-link smart-select">
+              <select name="car" multiple="multiple">
+                <optgroup label="Japanese">
+                  <option value="honda" selected="selected">Honda</option>
+                  <option value="lexus">Lexus</option>
+                  <option value="mazda">Mazda</option>
+                  <option value="nissan">Nissan</option>
+                  <option value="toyota">Toyota</option>
+                </optgroup>
+                <optgroup label="German">
+                  <option value="audi" selected="selected">Audi</option>
+                  <option value="bmw">BMW</option>
+                  <option value="mercedes">Mercedes</option>
+                  <option value="vw">Volkswagen</option>
+                  <option value="volvo">Volvo</option>
+                </optgroup>
+                <optgroup label="American">
+                  <option value="cadillac">Cadillac</option>
+                  <option value="chrysler">Chrysler</option>
+                  <option value="dodge">Dodge</option>
+                  <option value="ford" selected="selected">Ford</option>
+                </optgroup>
+              </select>
+              <div class="item-content">
+                <div class="item-inner">
+                  <div class="item-title">Car</div>
+                </div>
+              </div></a></li>
+          <li><a href="#" data-open-in="popup" class="item-link smart-select">
+              <select name="mac-windows">
+                <option value="mac" selected="selected">Mac</option>
+                <option value="windows">Windows</option>
+              </select>
+              <div class="item-content">
+                <div class="item-inner">
+                  <div class="item-title">Mac or Windows</div>
+                </div>
+              </div></a></li>
+        </ul>
+      </div>
+      <div class="content-block">Smart selects loaded in a picker</div>
+      <div class="list-block">
+        <ul>
+          <li><a href="#" data-open-in="picker" class="item-link smart-select">
+              <select name="fruits">
+                <option value="apple" selected="selected">Apple</option>
+                <option value="pineapple">Pineapple</option>
+                <option value="pear">Pear</option>
+                <option value="orange">Orange</option>
+                <option value="melon">Melon</option>
+                <option value="peach">Peach</option>
+                <option value="banana">Banana</option>
+              </select>
+              <div class="item-content">
+                <div class="item-inner">
+                  <div class="item-title">Fruit</div>
+                </div>
+              </div></a></li>
+          <li><a href="#" data-open-in="picker" data-picker-close-text="Close Cars" class="item-link smart-select">
+              <select name="car" multiple="multiple">
+                <optgroup label="Japanese">
+                  <option value="honda" selected="selected">Honda</option>
+                  <option value="lexus">Lexus</option>
+                  <option value="mazda">Mazda</option>
+                  <option value="nissan">Nissan</option>
+                  <option value="toyota">Toyota</option>
+                </optgroup>
+                <optgroup label="German">
+                  <option value="audi" selected="selected">Audi</option>
+                  <option value="bmw">BMW</option>
+                  <option value="mercedes">Mercedes</option>
+                  <option value="vw">Volkswagen</option>
+                  <option value="volvo">Volvo</option>
+                </optgroup>
+                <optgroup label="American">
+                  <option value="cadillac">Cadillac</option>
+                  <option value="chrysler">Chrysler</option>
+                  <option value="dodge">Dodge</option>
+                  <option value="ford" selected="selected">Ford</option>
+                </optgroup>
+              </select>
+              <div class="item-content">
+                <div class="item-inner">
+                  <div class="item-title">Car</div>
+                </div>
+              </div></a></li>
+          <li><a href="#" data-open-in="picker" data-picker-height="400px" class="item-link smart-select">
+              <select name="mac-windows">
+                <option value="mac" selected="selected">Mac</option>
+                <option value="windows">Windows</option>
+              </select>
+              <div class="item-content">
+                <div class="item-inner">
+                  <div class="item-title">Mac or Windows</div>
+                </div>
+              </div></a></li>
+        </ul>
+      </div>
     </div>
   </div>
 </div>

--- a/kitchen-sink-ios/jade/forms-selects.jade
+++ b/kitchen-sink-ios/jade/forms-selects.jade
@@ -58,3 +58,97 @@
               .item-content
                 .item-inner
                   .item-title Mac or Windows
+      .content-block Smart selects loaded in a popup
+      .list-block
+        ul
+          li
+            a(href="#" data-open-in="popup").item-link.smart-select
+              select(name="fruits")
+                option(value="apple", selected=true) Apple
+                option(value="pineapple") Pineapple
+                option(value="pear") Pear
+                option(value="orange") Orange
+                option(value="melon") Melon
+                option(value="peach") Peach
+                option(value="banana") Banana
+              .item-content
+                .item-inner
+                  .item-title Fruit
+          li
+            a(href="#" data-open-in="popup" data-popup-close-text="Close Cars" data-searchbar="true" data-searchbar-placeholder="Search cars").item-link.smart-select
+              select(name="car", multiple)
+                optgroup(label="Japanese")
+                  option(value="honda", selected=true) Honda
+                  option(value="lexus") Lexus
+                  option(value="mazda") Mazda
+                  option(value="nissan") Nissan
+                  option(value="toyota") Toyota
+                optgroup(label="German")
+                  option(value="audi", selected=true) Audi
+                  option(value="bmw") BMW
+                  option(value="mercedes") Mercedes
+                  option(value="vw") Volkswagen
+                  option(value="volvo") Volvo
+                optgroup(label="American")
+                  option(value="cadillac") Cadillac
+                  option(value="chrysler") Chrysler
+                  option(value="dodge") Dodge
+                  option(value="ford", selected=true) Ford
+              .item-content
+                .item-inner
+                  .item-title Car
+          li
+            a(href="#" data-open-in="popup").item-link.smart-select
+              select(name="mac-windows")
+                option(value="mac", selected=true) Mac
+                option(value="windows") Windows
+              .item-content
+                .item-inner
+                  .item-title Mac or Windows
+      .content-block Smart selects loaded in a picker
+      .list-block
+        ul
+          li
+            a(href="#" data-open-in="picker").item-link.smart-select
+              select(name="fruits")
+                option(value="apple", selected=true) Apple
+                option(value="pineapple") Pineapple
+                option(value="pear") Pear
+                option(value="orange") Orange
+                option(value="melon") Melon
+                option(value="peach") Peach
+                option(value="banana") Banana
+              .item-content
+                .item-inner
+                  .item-title Fruit
+          li
+            a(href="#" data-open-in="picker" data-picker-close-text="Close Cars").item-link.smart-select
+              select(name="car", multiple)
+                optgroup(label="Japanese")
+                  option(value="honda", selected=true) Honda
+                  option(value="lexus") Lexus
+                  option(value="mazda") Mazda
+                  option(value="nissan") Nissan
+                  option(value="toyota") Toyota
+                optgroup(label="German")
+                  option(value="audi", selected=true) Audi
+                  option(value="bmw") BMW
+                  option(value="mercedes") Mercedes
+                  option(value="vw") Volkswagen
+                  option(value="volvo") Volvo
+                optgroup(label="American")
+                  option(value="cadillac") Cadillac
+                  option(value="chrysler") Chrysler
+                  option(value="dodge") Dodge
+                  option(value="ford", selected=true) Ford
+              .item-content
+                .item-inner
+                  .item-title Car
+          li
+            a(href="#" data-open-in="picker" data-picker-height="400px").item-link.smart-select
+              select(name="mac-windows")
+                option(value="mac", selected=true) Mac
+                option(value="windows") Windows
+              .item-content
+                .item-inner
+                  .item-title Mac or Windows

--- a/kitchen-sink-material/forms-selects.html
+++ b/kitchen-sink-material/forms-selects.html
@@ -65,6 +65,122 @@
               </div>
             </div></a></li>
       </ul>
+      <div class="content-block">Smart selects loaded in a popup</div>
+      <div class="list-block">
+        <ul>
+          <li><a href="#" data-open-in="popup" class="item-link smart-select">
+              <select name="fruits">
+                <option value="apple" selected="selected">Apple</option>
+                <option value="pineapple">Pineapple</option>
+                <option value="pear">Pear</option>
+                <option value="orange">Orange</option>
+                <option value="melon">Melon</option>
+                <option value="peach">Peach</option>
+                <option value="banana">Banana</option>
+              </select>
+              <div class="item-content">
+                <div class="item-inner">
+                  <div class="item-title">Fruit</div>
+                </div>
+              </div></a></li>
+          <li><a href="#" data-open-in="popup" data-popup-close-text="Close Cars" data-searchbar="true" data-searchbar-placeholder="Search cars" class="item-link smart-select">
+              <select name="car" multiple="multiple">
+                <optgroup label="Japanese">
+                  <option value="honda" selected="selected">Honda</option>
+                  <option value="lexus">Lexus</option>
+                  <option value="mazda">Mazda</option>
+                  <option value="nissan">Nissan</option>
+                  <option value="toyota">Toyota</option>
+                </optgroup>
+                <optgroup label="German">
+                  <option value="audi" selected="selected">Audi</option>
+                  <option value="bmw">BMW</option>
+                  <option value="mercedes">Mercedes</option>
+                  <option value="vw">Volkswagen</option>
+                  <option value="volvo">Volvo</option>
+                </optgroup>
+                <optgroup label="American">
+                  <option value="cadillac">Cadillac</option>
+                  <option value="chrysler">Chrysler</option>
+                  <option value="dodge">Dodge</option>
+                  <option value="ford" selected="selected">Ford</option>
+                </optgroup>
+              </select>
+              <div class="item-content">
+                <div class="item-inner">
+                  <div class="item-title">Car</div>
+                </div>
+              </div></a></li>
+          <li><a href="#" data-open-in="popup" class="item-link smart-select">
+              <select name="mac-windows">
+                <option value="mac" selected="selected">Mac</option>
+                <option value="windows">Windows</option>
+              </select>
+              <div class="item-content">
+                <div class="item-inner">
+                  <div class="item-title">Mac or Windows</div>
+                </div>
+              </div></a></li>
+        </ul>
+      </div>
+      <div class="content-block">Smart selects loaded in a picker</div>
+      <div class="list-block">
+        <ul>
+          <li><a href="#" data-open-in="picker" class="item-link smart-select">
+              <select name="fruits">
+                <option value="apple" selected="selected">Apple</option>
+                <option value="pineapple">Pineapple</option>
+                <option value="pear">Pear</option>
+                <option value="orange">Orange</option>
+                <option value="melon">Melon</option>
+                <option value="peach">Peach</option>
+                <option value="banana">Banana</option>
+              </select>
+              <div class="item-content">
+                <div class="item-inner">
+                  <div class="item-title">Fruit</div>
+                </div>
+              </div></a></li>
+          <li><a href="#" data-open-in="picker" data-picker-close-text="Close Cars" class="item-link smart-select">
+              <select name="car" multiple="multiple">
+                <optgroup label="Japanese">
+                  <option value="honda" selected="selected">Honda</option>
+                  <option value="lexus">Lexus</option>
+                  <option value="mazda">Mazda</option>
+                  <option value="nissan">Nissan</option>
+                  <option value="toyota">Toyota</option>
+                </optgroup>
+                <optgroup label="German">
+                  <option value="audi" selected="selected">Audi</option>
+                  <option value="bmw">BMW</option>
+                  <option value="mercedes">Mercedes</option>
+                  <option value="vw">Volkswagen</option>
+                  <option value="volvo">Volvo</option>
+                </optgroup>
+                <optgroup label="American">
+                  <option value="cadillac">Cadillac</option>
+                  <option value="chrysler">Chrysler</option>
+                  <option value="dodge">Dodge</option>
+                  <option value="ford" selected="selected">Ford</option>
+                </optgroup>
+              </select>
+              <div class="item-content">
+                <div class="item-inner">
+                  <div class="item-title">Car</div>
+                </div>
+              </div></a></li>
+          <li><a href="#" data-open-in="picker" data-picker-height="400px" class="item-link smart-select">
+              <select name="mac-windows">
+                <option value="mac" selected="selected">Mac</option>
+                <option value="windows">Windows</option>
+              </select>
+              <div class="item-content">
+                <div class="item-inner">
+                  <div class="item-title">Mac or Windows</div>
+                </div>
+              </div></a></li>
+        </ul>
+      </div>
     </div>
   </div>
 </div>

--- a/kitchen-sink-material/jade/forms-selects.jade
+++ b/kitchen-sink-material/jade/forms-selects.jade
@@ -56,3 +56,97 @@
             .item-content
               .item-inner
                 .item-title Mac or Windows
+      .content-block Smart selects loaded in a popup
+      .list-block
+        ul
+          li
+            a(href="#" data-open-in="popup").item-link.smart-select
+              select(name="fruits")
+                option(value="apple", selected=true) Apple
+                option(value="pineapple") Pineapple
+                option(value="pear") Pear
+                option(value="orange") Orange
+                option(value="melon") Melon
+                option(value="peach") Peach
+                option(value="banana") Banana
+              .item-content
+                .item-inner
+                  .item-title Fruit
+          li
+            a(href="#" data-open-in="popup" data-popup-close-text="Close Cars" data-searchbar="true" data-searchbar-placeholder="Search cars").item-link.smart-select
+              select(name="car", multiple)
+                optgroup(label="Japanese")
+                  option(value="honda", selected=true) Honda
+                  option(value="lexus") Lexus
+                  option(value="mazda") Mazda
+                  option(value="nissan") Nissan
+                  option(value="toyota") Toyota
+                optgroup(label="German")
+                  option(value="audi", selected=true) Audi
+                  option(value="bmw") BMW
+                  option(value="mercedes") Mercedes
+                  option(value="vw") Volkswagen
+                  option(value="volvo") Volvo
+                optgroup(label="American")
+                  option(value="cadillac") Cadillac
+                  option(value="chrysler") Chrysler
+                  option(value="dodge") Dodge
+                  option(value="ford", selected=true) Ford
+              .item-content
+                .item-inner
+                  .item-title Car
+          li
+            a(href="#" data-open-in="popup").item-link.smart-select
+              select(name="mac-windows")
+                option(value="mac", selected=true) Mac
+                option(value="windows") Windows
+              .item-content
+                .item-inner
+                  .item-title Mac or Windows
+      .content-block Smart selects loaded in a picker
+      .list-block
+        ul
+          li
+            a(href="#" data-open-in="picker").item-link.smart-select
+              select(name="fruits")
+                option(value="apple", selected=true) Apple
+                option(value="pineapple") Pineapple
+                option(value="pear") Pear
+                option(value="orange") Orange
+                option(value="melon") Melon
+                option(value="peach") Peach
+                option(value="banana") Banana
+              .item-content
+                .item-inner
+                  .item-title Fruit
+          li
+            a(href="#" data-open-in="picker" data-picker-close-text="Close Cars").item-link.smart-select
+              select(name="car", multiple)
+                optgroup(label="Japanese")
+                  option(value="honda", selected=true) Honda
+                  option(value="lexus") Lexus
+                  option(value="mazda") Mazda
+                  option(value="nissan") Nissan
+                  option(value="toyota") Toyota
+                optgroup(label="German")
+                  option(value="audi", selected=true) Audi
+                  option(value="bmw") BMW
+                  option(value="mercedes") Mercedes
+                  option(value="vw") Volkswagen
+                  option(value="volvo") Volvo
+                optgroup(label="American")
+                  option(value="cadillac") Cadillac
+                  option(value="chrysler") Chrysler
+                  option(value="dodge") Dodge
+                  option(value="ford", selected=true) Ford
+              .item-content
+                .item-inner
+                  .item-title Car
+          li
+            a(href="#" data-open-in="picker" data-picker-height="400px").item-link.smart-select
+              select(name="mac-windows")
+                option(value="mac", selected=true) Mac
+                option(value="windows") Windows
+              .item-content
+                .item-inner
+                  .item-title Mac or Windows

--- a/src/js/framework7/f7-intro.js
+++ b/src/js/framework7/f7-intro.js
@@ -72,6 +72,8 @@ window.Framework7 = function (params) {
         // Smart Select Back link template
         smartSelectOpenIn: 'page', // or 'popup' or 'picker'
         smartSelectBackText: 'Back',
+        smartSelectClearSelectText: 'clear {{numSelected}} items',
+        smartSelectSelectAllText: 'select all',
         smartSelectPopupCloseText: 'Close',
         smartSelectPickerCloseText: 'Done',
         smartSelectSearchbar: false,

--- a/src/js/framework7/smart-select.js
+++ b/src/js/framework7/smart-select.js
@@ -428,15 +428,11 @@ app.smartSelectOpen = function (smartSelect, reLayout) {
     function handleInputs(container, navbarInnerContainer) {
         container = $(container);
 
-        var clearSelectButton;
-        clearSelectButton = container.find('.navbar .clear-select');
-        if (!clearSelectButton.length && navbarInnerContainer) {
-            clearSelectButton = $(navbarInnerContainer).find('.clear-select');
-        }
-        if (clearSelectButton) {
-            $(clearSelectButton).on('click', function(e) {
+        var clearSelectButtonContainer = navbarInnerContainer ? $(navbarInnerContainer) : container.find('.navbar');
+        if (clearSelectButtonContainer) {
+            clearSelectButtonContainer.on('click', '.clear-select', function(e) {
+                e.preventDefault();
                 var clearSelection = $$(container).find('input[type="checkbox"]:checked').length > 0;
-                e.target.innerText = clearSelection ? selectAllText : clearSelectText;
                 $$(container).find('label').each(function(i, label) {
                     if (clearSelection && $$(label).find('input[type="checkbox"]:checked').length) {
                         $$(label).click();


### PR DESCRIPTION
This commit adds a button at the top right of a smart select which shows you how many items are selected, eg. "clear 5 items" and when no items are selected shows "select all"

This lets you select or deselect multiple items at the same time. 

Does not activate on:

- virtual lists
- pickers
- non multiple smart selects

If this feature is accepted, I'll update the docs as well.