### PR TITLE
:bug: Issue #992: app.hidePreloader can close the wrong modal

### DIFF
--- a/src/js/framework7/modals.js
+++ b/src/js/framework7/modals.js
@@ -160,7 +160,7 @@ app.showPreloader = function (title) {
     });
 };
 app.hidePreloader = function () {
-    app.closeModal('.modal.modal-in');
+    app.closeModal('.modal-preloader');
 };
 app.showIndicator = function () {
     if ($('.preloader-indicator-overlay').length > 0) return;


### PR DESCRIPTION
Fixes issue #992. Closes preloader but not other modal dialogs if they are also open.