### PR TITLE
Allow User Specified Ratio for Lazy Load

### DIFF
--- a/src/js/framework7/lazy-load.js
+++ b/src/js/framework7/lazy-load.js
@@ -33,7 +33,7 @@ app.initImagesLazyLoad = function (pageContainer) {
         placeholderSrc = app.params.imagesLazyLoadPlaceholder;
     }
     if (app.params.imagesLazyLoadPlaceholder !== false) lazyLoadImages.each(function(){
-        if ($(this).attr('data-src')) $(this).attr('src', placeholderSrc);
+        if ($(this).attr('data-src') && !$(this).attr('src')) $(this).attr('src', placeholderSrc);
     });
 
     // load image


### PR DESCRIPTION
This allows users to specify the initial src attribute on the image tags so they can choose different placeholder images that can vary in ratio. Rather than one global placeholder image.

Fixes #928