### PR TITLE
Adds an onLazyLoad Callback

### DIFF
--- a/src/js/framework7/lazy-load.js
+++ b/src/js/framework7/lazy-load.js
@@ -94,6 +94,9 @@ app.initImagesLazyLoad = function (pageContainer) {
         image.onload = onLoad;
         image.onerror = onError;
         image.src =src;
+		
+		// Add loaded callback
+		if (app.params.onLazyLoad && !el.hasClass('lazy-loaded')) app.params.onLazyLoad(el);
     }
     function lazyHandler() {
         lazyLoadImages = pageContainer.find('.lazy');


### PR DESCRIPTION
It is sometimes really useful to detect when an image has been loaded via lazy load.

This adds this functionality.

```
var myApp = new Framework7({
     onLazyLoad: function (el) {
          console.log(el.attr('data-src'));
     }
});
```