### PR TITLE
Fix touch detection on Windows browsers.

### DIFF
--- a/src/js/dom7/dom7-utils.js
+++ b/src/js/dom7/dom7-utils.js
@@ -190,7 +190,7 @@ $.cancelAnimationFrame = function (id) {
         return window.clearTimeout(id);
     }
 };
-$.supportTouch = !!(('ontouchstart' in window) || window.DocumentTouch && document instanceof DocumentTouch);
+$.supportTouch = !!(('ontouchstart' in window && window.ontouchstart != null) || window.DocumentTouch && document instanceof DocumentTouch);
 
 // Remove Diacritics
 var defaultDiacriticsRemovalap = [

--- a/src/js/framework7/proto-support.js
+++ b/src/js/framework7/proto-support.js
@@ -3,7 +3,7 @@ Features Support Detection
 ===========================*/
 Framework7.prototype.support = (function () {
     var support = {
-        touch: !!(('ontouchstart' in window) || window.DocumentTouch && document instanceof DocumentTouch),
+        touch: !!(('ontouchstart' in window && window.ontouchstart != null) || window.DocumentTouch && document instanceof DocumentTouch),
         passiveListener: (function () {
             var supportsPassive = false;
             try {

--- a/src/js/swiper/swiper.js
+++ b/src/js/swiper/swiper.js
@@ -4005,7 +4005,7 @@ Swiper.prototype = {
     ====================================================*/
     support: {
         touch : (window.Modernizr && Modernizr.touch === true) || (function () {
-            return !!(('ontouchstart' in window) || window.DocumentTouch && document instanceof DocumentTouch);
+            return !!(('ontouchstart' in window && window.ontouchstart != null) || window.DocumentTouch && document instanceof DocumentTouch);
         })(),
 
         transforms3d : (window.Modernizr && Modernizr.csstransforms3d === true) || (function () {


### PR DESCRIPTION
Chrome, IE, Firefox all have a 'null' 'ontouchstart' defined.
This broke touch detection, and hence things like listview reordering, swiping, ...

Fixes: #1089 