### PR TITLE
Fix windows device detection error

### DIFF
--- a/src/js/framework7/proto-device.js
+++ b/src/js/framework7/proto-device.js
@@ -6,7 +6,7 @@ Framework7.prototype.device = (function () {
     var ua = navigator.userAgent;
     var $ = Dom7;
 
-    var windows = /windows phone/i.test(ua);
+    var windows = ua.match(/(Windows Phone);?[\s\/]+([\d.]+)?/);
     var android = ua.match(/(Android);?[\s\/]+([\d.]+)?/);
     var ipad = ua.match(/(iPad).*OS\s([\d_]+)/);
     var ipod = ua.match(/(iPod)(.*OS\s([\d_]+))?/);
@@ -17,6 +17,7 @@ Framework7.prototype.device = (function () {
     // Windows
     if (windows) {
         device.os = 'windows';
+        device.osVersion = windows[2];
         device.windows = true;
     }
     // Android


### PR DESCRIPTION
Fix error _"Unable to get property 'split' of undefined or null reference framework7.js (13461,17)"_ if using the device detection on windows phones.