### PR TITLE
Popover click outside action

### DIFF
--- a/src/js/framework7/clicks.js
+++ b/src/js/framework7/clicks.js
@@ -156,7 +156,7 @@ app.initClickEvents = function () {
                 app.closeModal('.actions-modal.modal-in');
 
             if ($('.popover.modal-in').length > 0 && app.params.popoverCloseByOutside)
-		app.closeModal('.popover.modal-in');
+                app.closeModal('.popover.modal-in');
         }
         if (clicked.hasClass('popup-overlay')) {
             if ($('.popup.modal-in').length > 0 && app.params.popupCloseByOutside)

--- a/src/js/framework7/clicks.js
+++ b/src/js/framework7/clicks.js
@@ -155,7 +155,8 @@ app.initClickEvents = function () {
             if ($('.actions-modal.modal-in').length > 0 && app.params.actionsCloseByOutside)
                 app.closeModal('.actions-modal.modal-in');
 
-            if ($('.popover.modal-in').length > 0) app.closeModal('.popover.modal-in');
+            if ($('.popover.modal-in').length > 0 && app.params.popoverCloseByOutside)
+		app.closeModal('.popover.modal-in');
         }
         if (clicked.hasClass('popup-overlay')) {
             if ($('.popup.modal-in').length > 0 && app.params.popupCloseByOutside)

--- a/src/js/framework7/f7-intro.js
+++ b/src/js/framework7/f7-intro.js
@@ -98,7 +98,7 @@ window.Framework7 = function (params) {
         modalCloseByOutside: false,
         actionsCloseByOutside: true,
         popupCloseByOutside: true,
-	popoverCloseByOutside: true,
+        popoverCloseByOutside: true,
         modalPreloaderTitle: 'Loading... ',
         modalStack: true,
         modalsMoveToRoot: true,

--- a/src/js/framework7/f7-intro.js
+++ b/src/js/framework7/f7-intro.js
@@ -98,6 +98,7 @@ window.Framework7 = function (params) {
         modalCloseByOutside: false,
         actionsCloseByOutside: true,
         popupCloseByOutside: true,
+	popoverCloseByOutside: true,
         modalPreloaderTitle: 'Loading... ',
         modalStack: true,
         modalsMoveToRoot: true,

--- a/src/js/framework7/modals.js
+++ b/src/js/framework7/modals.js
@@ -271,8 +271,9 @@ app.actions = function (target, params, animated) {
     if (!toPopover) app.openModal(modal, animated);
     return modal[0];
 };
-app.popover = function (modal, target, removeOnClose, animated) {
+app.popover = function (modal, target, removeOnClose, animated, closeByOutside) {
     if (typeof removeOnClose === 'undefined') removeOnClose = true;
+    if (typeof closeByOutside === 'undefined') closeByOutside = true;
     if (typeof animated === 'undefined') animated = true;
     if (typeof modal === 'string' && modal.indexOf('<') >= 0) {
         var _modal = document.createElement('div');
@@ -280,6 +281,7 @@ app.popover = function (modal, target, removeOnClose, animated) {
         if (_modal.childNodes.length > 0) {
             modal = _modal.childNodes[0];
             if (removeOnClose) modal.classList.add('remove-on-close');
+            if (!closeByOutside) modal.classList.add('ignore-close-by-outside');
             app.root.append(modal);
         }
         else return false; //nothing found
@@ -289,6 +291,7 @@ app.popover = function (modal, target, removeOnClose, animated) {
     if (modal.length === 0 || target.length === 0) return false;
     if (modal.parents('body').length === 0) {
         if (removeOnClose) modal.addClass('remove-on-close');
+        if (!closeByOutside) modal.addClass.add('ignore-close-by-outside');
         app.root.append(modal[0]);
     }
     if (modal.find('.popover-angle').length === 0 && !app.params.material) {
@@ -665,6 +668,11 @@ app.closeModal = function (modal, animated) {
     if (isActions) modalType = 'actions';
 
     var removeOnClose = modal.hasClass('remove-on-close');
+    
+    // ignore close popover
+    if (isPopover && modal.hasClass('ignore-close-by-outside')) {
+        return;
+    }
 
     // For Actions
     var keepOnClose = modal.hasClass('keep-on-close');


### PR DESCRIPTION
# **Description:**
This pull request is intended to be a contribution to the Framework7 framework.

Similar to other properties available when a Framework7 instance is created, the **_popoverCloseByOutside_** allows developers to tell the Framework7 that a popover should not be closed when clicking outside of the popover (for example, clicking on the modal-in overlay).

The **_popoverCloseByOutside_** property was added to the **f7-intro.js** file with default **true**.
The **_popoverCloseByOutside_** is used inside **clicks.js** file which evaluates if a popover should be closed only when **_popoverCloseByOutside_** property is set to **true**.

# Commit message:
```
Added new property to Framework7 instance
Added popoverCloseByOutside property with default 'true'
Modified clicks.js to evaluate if popover should be closed on modal-in click
```