### PR TITLE
Fix suppressed errors for code inside ajax

### DIFF
--- a/src/js/dom7/dom7-ajax.js
+++ b/src/js/dom7/dom7-ajax.js
@@ -215,6 +215,7 @@ $.ajax = function (options) {
                     fireAjaxCallback('ajaxSuccess ajax:success', {xhr: xhr}, 'success', responseData, xhr.status, xhr);
                 }
                 catch (err) {
+                    console.error(err.stack);
                     fireAjaxCallback('ajaxError ajax:error', {xhr: xhr, parseerror: true}, 'error', xhr, 'parseerror');
                 }
             }


### PR DESCRIPTION
If wrong code is in an ajax call, it has been suppressed by Framework7.
With this fix it throws the error in the console.