### PR TITLE
Update panels.js - Fix swipe panel bug

### DIFF
--- a/src/js/framework7/panels.js
+++ b/src/js/framework7/panels.js
@@ -453,7 +453,6 @@ app.initSwipePanels = function () {
                     $('body').addClass('panel-closing');
                     target.transitionEnd(function () {
                         panel.trigger('close panel:closed');
-                        panel.css({display: ''});
                         $('body').removeClass('panel-closing');
                         app.allowPanelOpen = true;
                     });


### PR DESCRIPTION
Remove the line 456, this cause the panel disappear in below case:

When you swipe a little distance to make the panel follow your finger and become partly visible, then release your finger and do the swipe action immediately to open the panel, the panel will be disappeared right after it become visible

#1468 