### PR TITLE
toggle `focus-state` and `not-empty-state` in material input form

### DIFF
--- a/src/js/framework7/material-inputs.js
+++ b/src/js/framework7/material-inputs.js
@@ -31,7 +31,7 @@ app.initMaterialWatchInputs = function () {
         var type = i.attr('type');
         if (notInputs.indexOf(type) >= 0) return;
         var els = i.add(i.parents('.item-input, .input-field')).add(i.parents('.item-inner').eq(0));
-        els.addClass('focus-state');
+        els.removeClass('not-empty-state').addClass('focus-state');
     }
     function removeFocusState(e) {
         /*jshint validthis:true*/
@@ -41,7 +41,7 @@ app.initMaterialWatchInputs = function () {
         var els = i.add(i.parents('.item-input, .input-field')).add(i.parents('.item-inner').eq(0));
         els.removeClass('focus-state');
         if (value && value.trim() !== '') {
-            els.addClass('not-empty-state');
+            els.removeClass('focus-state').addClass('not-empty-state');
         }
         else {
             els.removeClass('not-empty-state');

--- a/src/js/swiper/swiper.js
+++ b/src/js/swiper/swiper.js
@@ -675,7 +675,7 @@ window.Swiper = function (container, params) {
 
         // Find slides currently in view
         if(s.params.slidesPerView !== 'auto' && s.params.slidesPerView > 1) {
-            for (var i = 0; i < Math.ceil(s.params.slidesPerView); i++) {
+            for (i = 0; i < Math.ceil(s.params.slidesPerView); i++) {
                 var index = s.activeIndex + i;
                 if(index > s.slides.length) break;
                 activeSlides.push(s.slides.eq(index)[0]);
@@ -685,7 +685,7 @@ window.Swiper = function (container, params) {
         }
 
         // Find new height from heighest slide in view
-        for (var i = 0; i < activeSlides.length; i++) {
+        for (i = 0; i < activeSlides.length; i++) {
             if (typeof activeSlides[i] !== 'undefined') {
                 var height = activeSlides[i].offsetHeight;
                 newHeight = height > newHeight ? height : newHeight;

--- a/src/js/swiper/swiper.js
+++ b/src/js/swiper/swiper.js
@@ -675,7 +675,7 @@ window.Swiper = function (container, params) {
 
         // Find slides currently in view
         if(s.params.slidesPerView !== 'auto' && s.params.slidesPerView > 1) {
-            for (i = 0; i < Math.ceil(s.params.slidesPerView); i++) {
+            for (var i = 0; i < Math.ceil(s.params.slidesPerView); i++) {
                 var index = s.activeIndex + i;
                 if(index > s.slides.length) break;
                 activeSlides.push(s.slides.eq(index)[0]);
@@ -685,7 +685,7 @@ window.Swiper = function (container, params) {
         }
 
         // Find new height from heighest slide in view
-        for (i = 0; i < activeSlides.length; i++) {
+        for (var i = 0; i < activeSlides.length; i++) {
             if (typeof activeSlides[i] !== 'undefined') {
                 var height = activeSlides[i].offsetHeight;
                 newHeight = height > newHeight ? height : newHeight;

--- a/src/less/material/forms.less
+++ b/src/less/material/forms.less
@@ -100,8 +100,29 @@
         }
     }
     .focus-state {
+        &.item-inner {
+            .label {
+                color: @themeColor;
+            }
+        }
+        &.input-field:after,
+        .item-input-field:after {
+            background: @themeColor;
+        }
         .label, .floating-label {
             color: @themeColor;
+        }
+    }
+    .not-empty-state {
+        &.item-inner {
+            .label {
+                color: rgba(0, 0, 0, 0.65);
+            }
+        }
+        &.input-field:after,
+        .item-input-field:after {
+            background: rgba(0, 0, 0, 0.12);
+            transform: none !important;
         }
     }
 }


### PR DESCRIPTION
**Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.**
According to [this issue](https://github.com/nolimits4web/Framework7/issues/1516), the link below input value is not disappear because `focus-state` still exist although `not-empty-state` has been added to the input. So I remove `not-empty-state` class when input is on focus and remove `focus-state` when input is on blur. And then I add css styles of `.${STATE}.item-inner label, .${STATE}.input-field:after,  .${STATE} .item-input-field:after` with STATE value is `focus-state` and `not-empty-state`