### PR TITLE
FIX destroy pull to refresh bug - issue 1528

### DIFF
--- a/src/js/framework7/pull-to-refresh.js
+++ b/src/js/framework7/pull-to-refresh.js
@@ -180,14 +180,16 @@ app.initPullToRefresh = function (pageContainer) {
 
     // Detach Events on page remove
     if (page.length === 0) return;
-    function destroyPullToRefresh() {
-        eventsTarget.off(app.touchEvents.start, handleTouchStart, passiveListener);
-        eventsTarget.off(app.touchEvents.move, handleTouchMove, activeListener);
-        eventsTarget.off(app.touchEvents.end, handleTouchEnd, passiveListener);
+    function destroyPullToRefresh(destroyTarget) {
+        destroyTarget.off(app.touchEvents.start, handleTouchStart, passiveListener);
+        destroyTarget.off(app.touchEvents.move, handleTouchMove, activeListener);
+        destroyTarget.off(app.touchEvents.end, handleTouchEnd, passiveListener);
     }
-    eventsTarget[0].f7DestroyPullToRefresh = destroyPullToRefresh;
+    for (var i = 0; i < eventsTarget.length; i++) {
+        eventsTarget[i].f7DestroyPullToRefresh = destroyPullToRefresh;
+    }
     function detachEvents() {
-        destroyPullToRefresh();
+        destroyPullToRefresh(eventsTarget);
         page.off('page:beforeremove', detachEvents);
     }
     page.on('page:beforeremove', detachEvents);
@@ -219,5 +221,5 @@ app.destroyPullToRefresh = function (pageContainer) {
     pageContainer = $(pageContainer);
     var pullToRefreshContent = pageContainer.hasClass('pull-to-refresh-content') ? pageContainer : pageContainer.find('.pull-to-refresh-content');
     if (pullToRefreshContent.length === 0) return;
-    if (pullToRefreshContent[0].f7DestroyPullToRefresh) pullToRefreshContent[0].f7DestroyPullToRefresh();
+    if (pullToRefreshContent[0].f7DestroyPullToRefresh) pullToRefreshContent[0].f7DestroyPullToRefresh(pageContainer);
 };


### PR DESCRIPTION
please check the bug issue
issue link:    https://github.com/nolimits4web/Framework7/issues/1528

bug sample:  https://jsfiddle.net/mohshraim/s2n1p730/9/

changes should solve the problem..
added some variables as parameter for DestroyPullToRefresh function, please review the name and adjust it to appropriate name..

thanks
