### PR TITLE
Fix check to current page at view initialization

### DIFF
--- a/src/js/framework7/views.js
+++ b/src/js/framework7/views.js
@@ -122,7 +122,7 @@ var View = function (selector, params) {
     }
 
     // View startup URL
-    if (view.params.domCache && currentPage) {
+    if (view.params.domCache && currentPageData) {
         view.url = container.attr('data-url') || view.params.url || '#' + currentPage.attr('data-page');
         view.pagesCache[view.url] = currentPage.attr('data-page');
     }


### PR DESCRIPTION
Fix #1687

When pages element is empty currentPage variable is truthy but its length is 0. This is set view.url to '#undefined' and mangles the view page cache and history

When currentPageData is truthy means that currentPage is also truthy with length === 1, so a proper url can be set 
