### PR TITLE
DataTable Checkbox for 'select all' should only select checkboxes in …

### DIFF
--- a/kitchen-sink-ios/jade/data-table.jade
+++ b/kitchen-sink-ios/jade/data-table.jade
@@ -93,6 +93,11 @@
             th.numeric-cell Calories
             th.numeric-cell Fat (g)
             th.numeric-cell Carbs
+            th.checkbox-cell
+                label.form-checkbox
+                  input(type="checkbox")
+                  i
+                span In Stock
             th.numeric-cell Protein (g)
         tbody
           tr
@@ -104,6 +109,10 @@
             td.numeric-cell 159
             td.numeric-cell 6.0
             td.numeric-cell 24
+            td.checkbox-cell
+              label.form-checkbox
+                input(type="checkbox")
+                i
             td.numeric-cell 4.0
           tr
             td.checkbox-cell
@@ -114,6 +123,10 @@
             td.numeric-cell 237
             td.numeric-cell 9.0
             td.numeric-cell 37
+            td.checkbox-cell
+              label.form-checkbox
+                input(type="checkbox")
+                i
             td.numeric-cell 4.4
           tr
             td.checkbox-cell
@@ -124,6 +137,10 @@
             td.numeric-cell 262
             td.numeric-cell 16.0
             td.numeric-cell 24
+            td.checkbox-cell
+              label.form-checkbox
+                input(type="checkbox")
+                i
             td.numeric-cell 6.0
           tr
             td.checkbox-cell
@@ -134,6 +151,10 @@
             td.numeric-cell 305
             td.numeric-cell 3.7
             td.numeric-cell 67
+            td.checkbox-cell
+              label.form-checkbox
+                input(type="checkbox")
+                i
             td.numeric-cell 4.3
     .content-block-title Tablet-only columns
     .content-block

--- a/kitchen-sink-material/jade/data-table.jade
+++ b/kitchen-sink-material/jade/data-table.jade
@@ -92,6 +92,11 @@
             th.numeric-cell Calories
             th.numeric-cell Fat (g)
             th.numeric-cell Carbs
+            th.checkbox-cell
+              label.form-checkbox
+                input(type="checkbox")
+                i
+              span In Stock
             th.numeric-cell Protein (g)
         tbody
           tr
@@ -103,6 +108,10 @@
             td.numeric-cell 159
             td.numeric-cell 6.0
             td.numeric-cell 24
+            td.checkbox-cell
+              label.form-checkbox
+                input(type="checkbox")
+                i
             td.numeric-cell 4.0
           tr
             td.checkbox-cell
@@ -113,6 +122,10 @@
             td.numeric-cell 237
             td.numeric-cell 9.0
             td.numeric-cell 37
+            td.checkbox-cell
+              label.form-checkbox
+                input(type="checkbox")
+                i
             td.numeric-cell 4.4
           tr
             td.checkbox-cell
@@ -123,6 +136,10 @@
             td.numeric-cell 262
             td.numeric-cell 16.0
             td.numeric-cell 24
+            td.checkbox-cell
+              label.form-checkbox
+                input(type="checkbox")
+                i
             td.numeric-cell 6.0
           tr
             td.checkbox-cell
@@ -133,6 +150,10 @@
             td.numeric-cell 305
             td.numeric-cell 3.7
             td.numeric-cell 67
+            td.checkbox-cell
+              label.form-checkbox
+                input(type="checkbox")
+                i
             td.numeric-cell 4.3
     .content-block-title Tablet-only columns
     .content-block

--- a/src/js/framework7/data-table.js
+++ b/src/js/framework7/data-table.js
@@ -14,6 +14,13 @@ app.initDataTable = function (table) {
             tableHeaderSelected.find('.data-table-selected-count').text(checkedItems);
         }
     }
+    function toggleRowSelected (index, el, checked) {
+        // Select the row if the checkbox is the first column
+        if (index === 0) {
+            el[checked ? 'addClass': 'removeClass']('data-table-row-selected');
+        }
+    }
+
     table.on('change', '.checkbox-cell input[type="checkbox"]', function (e) {
         if (e.detail && e.detail._sentByF7DataTable) {
             // Scripted event, don't do anything
@@ -21,20 +28,24 @@ app.initDataTable = function (table) {
         }
         var input = $(this);
         var checked = input[0].checked;
-        if (input.parents('thead').length > 0) {
-            table
-                .find('tbody tr')[checked ? 'addClass': 'removeClass']('data-table-row-selected')
-                .find('input').prop('checked', checked).trigger('change', {_sentByF7DataTable: true});
+        var headerCell = input.parents('th');
+        var columnIndex = input.parents('td,th').index();
+
+        // If header checkbox exists
+        if (headerCell.length > 0) {
+            toggleRowSelected(columnIndex, table.find('tbody tr'), checked);            
+            table.find('tbody tr td:nth-child(' + (columnIndex +1) + ') input').prop('checked', checked).trigger('change', {_sentByF7DataTable: true});
         }
         else {
-            input.parents('tr')[checked ? 'addClass': 'removeClass']('data-table-row-selected');
+            toggleRowSelected(columnIndex, input.parents('tr'), checked);
+
             if (!checked) {
-                table.find('thead .checkbox-cell input[type="checkbox"]').prop('checked', false);
+                table.find('thead .checkbox-cell:nth-child(' + (columnIndex +1) + ') input[type="checkbox"]').prop('checked', false);
             }
             else {
                 // Check for all checked
-                if (table.find('tbody .checkbox-cell input[type="checkbox"]:checked').length === table.find('tbody tr').length) {
-                    table.find('thead .checkbox-cell input[type="checkbox"]').prop('checked', true).trigger('change', {_sentByF7DataTable: true});
+                if (table.find('tbody .checkbox-cell:nth-child(' + (columnIndex +1) + ') input[type="checkbox"]:checked').length === table.find('tbody tr').length) {
+                    table.find('thead .checkbox-cell:nth-child(' + (columnIndex +1) + ') input[type="checkbox"]').prop('checked', true).trigger('change', {_sentByF7DataTable: true});
                 }
             }
         }

--- a/src/less/ios/data-table.less
+++ b/src/less/ios/data-table.less
@@ -60,6 +60,11 @@
             & + td, & + th {
                 padding-left: 8px;
             }
+            label {
+                & + span{
+                    padding-left:8px;
+                }
+            }
         }
         &.actions-cell {
             text-align: right;

--- a/src/less/material/data-table.less
+++ b/src/less/material/data-table.less
@@ -70,6 +70,11 @@
             & + td, & + th {
                 padding-left: 12px;
             }
+            label {
+                & + span{
+                    padding-left:8px;
+                }
+            }
         }
         &.actions-cell {
             text-align: right;


### PR DESCRIPTION
…associated column.

Fixes for #1562 

I've changed behavior so that column header checkboxes only select that column. If the column checkbox belongs to the first column, then it will toggle the "selected row" state by adding the associated class. Let me know what you guys think makes sense.