### PR TITLE
Fix issue with wrong element selected when scrolling

### DIFF
--- a/src/js/framework7/fast-clicks.js
+++ b/src/js/framework7/fast-clicks.js
@@ -251,7 +251,17 @@ app.initFastClicks = function () {
         }
         evt.initMouseEvent(eventType, true, true, window, 1, touch.screenX, touch.screenY, touch.clientX, touch.clientY, false, false, false, false, 0, null);
         evt.forwardedTouchEvent = true;
-        targetElement.dispatchEvent(evt);
+
+        if (app.device.ios && navigator.standalone) {
+            //Fix the issue happens in iOS home screen apps where the wrong element is selected during a momentum scroll.
+            //Upon tapping, we give the scrolling time to stop, then we grab the element based where the user tapped.
+            setTimeout(function () {
+                targetElement = document.elementFromPoint(e.changedTouches[0].clientX, e.changedTouches[0].clientY);
+                targetElement.dispatchEvent(evt);
+            }, 10);
+        } else {
+            targetElement.dispatchEvent(evt);
+        }
     }
 
     // Touch Handlers


### PR DESCRIPTION
In iOS home screen apps, when momentum scrolling is started and then an element is tapped while the element is still scrolling, the wrong element will be selected. This only happens with FastClicks enabled.

To reproduce, add the kitchen sink to home screen on an iOS device, start the main menu page scrolling, then tap on a link. Notice that you end up on a different page than the link you tapped.

Note that this fix does not ensure that `active-state` gets set on the correct element, but it does ensure that the click event gets fired for the right element. So for example, the you will now always be taken to the correct page in the kitchen sink, but the wrong link may be highlighted. Not perfect, but it is definitely an improvement.