### PR TITLE
[v2] Add check to $pageEl in pageCallback

### DIFF
--- a/src/modules/router/router-class.js
+++ b/src/modules/router/router-class.js
@@ -802,6 +802,7 @@ class Router extends Framework7Class {
     if (!pageEl) return;
     const router = this;
     const $pageEl = $(pageEl);
+    if (!$pageEl.length) return;
     const { route, on = {} } = options;
     const restoreScrollTopOnBack = router.params.restoreScrollTopOnBack;
 


### PR DESCRIPTION
It fixes a bug when there are currently no page in the view. POC at https://codepen.io/blikblum/pen/MvdrWO?editors=1011

When there's no page, the $oldPage is empty and when passed as argument to pageCallback ('beforeOut' callback) an exception occurs