### PR TITLE
Cleanup pageCallback: remove double check for callback argument

### DIFF
--- a/src/modules/router/router-class.js
+++ b/src/modules/router/router-class.js
@@ -861,11 +861,7 @@ class Router extends Framework7Class {
           $pageEl.off(`page:${eventName.split('page')[1].toLowerCase()}`, $pageEl[0].f7PageEvents[eventName]);
         });
       }
-    }
-
-    if (callback === 'beforeRemove') {
       $pageEl[0].f7Page = null;
-      page = null;
     }
   }
   saveHistory() {


### PR DESCRIPTION
This PR removes double check for callback argument (=== 'beforeRemove') in Router.pageCallback

Also remove setting page to null since, page is an internal variable not used elsewhere